### PR TITLE
Wrap targetargs in quotes to handle paths containing spaces

### DIFF
--- a/FineCodeCoverage/Core/OpenCover/OpenCoverUtil.cs
+++ b/FineCodeCoverage/Core/OpenCover/OpenCoverUtil.cs
@@ -279,8 +279,8 @@ namespace FineCodeCoverage.Engine.OpenCover
 				//filters.Add($@"-[{nameOnlyOfDll}]*");
 			}
 
-			opencoverSettings.Add($@" ""-targetargs:{project.TestDllFileInWorkFolder}"" ");
-			
+			opencoverSettings.Add($@" ""-targetargs:\""{project.TestDllFileInWorkFolder}\"""" ");
+
 			opencoverSettings.Add($@" ""-output:{ project.CoverToolOutputFile }"" ");
 
 			Logger.Log($"{title} Arguments {Environment.NewLine}{string.Join($"{Environment.NewLine}", opencoverSettings)}");


### PR DESCRIPTION
Fixes #41 

## Issue

When the path to the code/solution has a space in it, the code coverage tool fails due to OpenCover requiring those arguments to be wrapped in quotes.

## Solution

Wrap the `targetargs` parameter value in quotes, to allow for spaces within the path. See: [Notes On Spaces In Arguments](https://github.com/OpenCover/opencover/wiki/Usage#notes-on-spaces-in-arguments)

