### PR TITLE
Use dte for referenced projects and assembly name

### DIFF
--- a/FineCodeCoverage/Core/CoverageUIEvents.cs
+++ b/FineCodeCoverage/Core/CoverageUIEvents.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace FineCodeCoverage.Engine
+{
+	public class UpdateMarginTagsEventArgs : EventArgs
+	{
+	}
+
+	public class UpdateOutputWindowEventArgs : EventArgs
+	{
+		public string HtmlContent { get; set; }
+	}
+
+	public delegate void UpdateMarginTagsDelegate(UpdateMarginTagsEventArgs e);
+	public delegate void UpdateOutputWindowDelegate(UpdateOutputWindowEventArgs e);
+}

--- a/FineCodeCoverage/Core/Coverlet/CoverletUtil.cs
+++ b/FineCodeCoverage/Core/Coverlet/CoverletUtil.cs
@@ -1,15 +1,15 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Diagnostics;
-using System.Collections.Generic;
+using System.Threading.Tasks;
 using FineCodeCoverage.Engine.Model;
-using System.Diagnostics.CodeAnalysis;
 using FineCodeCoverage.Engine.Utilities;
 
 namespace FineCodeCoverage.Engine.Coverlet
 {
-	internal class CoverletUtil
+    internal class CoverletUtil
 	{
 		public const string CoverletName = "coverlet.console";
 		public static string CoverletExePath { get; private set; }
@@ -149,8 +149,7 @@ namespace FineCodeCoverage.Engine.Coverlet
 			Logger.Log(title, processOutput);
 		}
 
-		[SuppressMessage("Usage", "VSTHRD002:Avoid problematic synchronous waits")]
-		public static bool RunCoverlet(CoverageProject project, bool throwError = false)
+		public static async Task<bool> RunCoverletAsync(CoverageProject project, bool throwError = false)
 		{
 			var title = $"Coverlet Run ({project.ProjectName})";
 
@@ -205,15 +204,14 @@ namespace FineCodeCoverage.Engine.Coverlet
 
 			Logger.Log($"{title} Arguments {Environment.NewLine}{string.Join($"{Environment.NewLine}", coverletSettings)}");
 
-			var result = ProcessUtil
+			var result = await ProcessUtil
 			.ExecuteAsync(new ExecuteRequest
 			{
 				FilePath = CoverletExePath,
 				Arguments = string.Join(" ", coverletSettings),
 				WorkingDirectory = project.ProjectOutputFolder
-			})
-			.GetAwaiter()
-			.GetResult();
+			});
+			
 
 			if(result != null)
             {

--- a/FineCodeCoverage/Core/Model/CoverageProject.cs
+++ b/FineCodeCoverage/Core/Model/CoverageProject.cs
@@ -2,15 +2,19 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Xml.Linq;
+using System.Xml.XPath;
+using EnvDTE;
 using FineCodeCoverage.Core.Model;
 using FineCodeCoverage.Core.Utilities;
 using FineCodeCoverage.Engine.FileSynchronization;
 using FineCodeCoverage.Options;
+using Microsoft.VisualStudio.Shell;
 
 namespace FineCodeCoverage.Engine.Model
 {
-	internal class CoverageProject
+    internal class CoverageProject
 	{
 		private string fccPath;
 		private string fccFolderName = "fine-code-coverage";
@@ -18,8 +22,85 @@ namespace FineCodeCoverage.Engine.Model
 		private string buildOutputPath;
 		private string coverageToolOutputFolderName = "coverage-tool-output";
 
-		public string ProjectFolder => Path.GetDirectoryName(ProjectFile);
-		public bool IsDotNetSdkStyle { get; set; }
+		public bool IsDotNetSdkStyle(){
+			return ProjectFileXElement
+			.DescendantsAndSelf()
+			.Where(x =>
+			{
+				//https://docs.microsoft.com/en-us/visualstudio/msbuild/how-to-use-project-sdk?view=vs-2019
+
+				/*
+				<Project Sdk="My.Custom.Sdk">
+					...
+				</Project>
+				<Project Sdk="My.Custom.Sdk/1.2.3">
+					...
+				</Project>
+				*/
+				if
+				(
+					x?.Name?.LocalName?.Equals("Project", StringComparison.OrdinalIgnoreCase) == true &&
+					x?.Parent == null
+				)
+				{
+					var sdkAttr = x?.Attributes()?.FirstOrDefault(attr => attr?.Name?.LocalName?.Equals("Sdk", StringComparison.OrdinalIgnoreCase) == true);
+
+					if (sdkAttr?.Value?.Trim()?.StartsWith("Microsoft.NET.Sdk", StringComparison.OrdinalIgnoreCase) == true)
+					{
+						return true;
+					}
+				}
+
+				/*
+				<Project>
+					<Sdk Name="My.Custom.Sdk" Version="1.2.3" />
+					...
+				</Project>
+				*/
+				if
+				(
+					x?.Name?.LocalName?.Equals("Sdk", StringComparison.OrdinalIgnoreCase) == true &&
+					x?.Parent?.Name?.LocalName?.Equals("Project", StringComparison.OrdinalIgnoreCase) == true &&
+					x?.Parent?.Parent == null
+				)
+				{
+					var nameAttr = x?.Attributes()?.FirstOrDefault(attr => attr?.Name?.LocalName?.Equals("Name", StringComparison.OrdinalIgnoreCase) == true);
+
+					if (nameAttr?.Value?.Trim()?.StartsWith("Microsoft.NET.Sdk", StringComparison.OrdinalIgnoreCase) == true)
+					{
+						return true;
+					}
+				}
+
+				/*
+				<Project>
+					<PropertyGroup>
+						<MyProperty>Value</MyProperty>
+					</PropertyGroup>
+					<Import Project="Sdk.props" Sdk="My.Custom.Sdk" />
+						...
+					<Import Project="Sdk.targets" Sdk="My.Custom.Sdk" />
+				</Project>
+				*/
+				if
+				(
+					x?.Name?.LocalName?.Equals("Import", StringComparison.OrdinalIgnoreCase) == true &&
+					x?.Parent?.Name?.LocalName?.Equals("Project", StringComparison.OrdinalIgnoreCase) == true &&
+					x?.Parent?.Parent == null
+				)
+				{
+					var sdkAttr = x?.Attributes()?.FirstOrDefault(attr => attr?.Name?.LocalName?.Equals("Sdk", StringComparison.OrdinalIgnoreCase) == true);
+
+					if (sdkAttr?.Value?.Trim()?.StartsWith("Microsoft.NET.Sdk", StringComparison.OrdinalIgnoreCase) == true)
+					{
+						return true;
+					}
+				}
+
+				return false;
+			})
+			.Any();
+		}
 		public string TestDllFile { get; set; }
 		public string ProjectOutputFolder => Path.GetDirectoryName(TestDllFile);
 		public string FailureDescription { get; set; }
@@ -28,16 +109,209 @@ namespace FineCodeCoverage.Engine.Model
 		public string ProjectFile { get; set; }
 		public string ProjectName { get; set; }
 		public string CoverageOutputFile { get; set; }
-		public AppOptions Settings { get; set; }
+
+		private bool TypeMatch(Type type, params Type[] otherTypes)
+		{
+			return (otherTypes ?? new Type[0]).Any(ot => type == ot);
+		}
+		
+		private AppOptions settings;
+		public AppOptions Settings
+		{
+			get
+			{
+				if(settings == null)
+                {
+					// get global settings
+
+					settings = AppOptions.Get();
+
+					/*
+					========================================
+					Process PropertyGroup settings
+					========================================
+					<PropertyGroup Label="FineCodeCoverage">
+						...
+					</PropertyGroup>
+					*/
+
+					var settingsPropertyGroup = ProjectFileXElement.XPathSelectElement($"/PropertyGroup[@Label='{Vsix.Code}']");
+
+					if (settingsPropertyGroup != null)
+					{
+						foreach (var property in settings.GetType().GetProperties())
+						{
+							try
+							{
+								var xproperty = settingsPropertyGroup.Descendants().FirstOrDefault(x => x.Name.LocalName.Equals(property.Name, StringComparison.OrdinalIgnoreCase));
+
+								if (xproperty == null)
+								{
+									continue;
+								}
+
+								var strValue = xproperty.Value;
+
+								if (string.IsNullOrWhiteSpace(strValue))
+								{
+									continue;
+								}
+
+								var strValueArr = strValue.Split('\n', '\r').Where(x => !string.IsNullOrWhiteSpace(x)).Select(x => x.Trim()).ToArray();
+
+								if (!strValue.Any())
+								{
+									continue;
+								}
+
+								if (TypeMatch(property.PropertyType, typeof(string)))
+								{
+									property.SetValue(settings, strValueArr.FirstOrDefault());
+								}
+								else if (TypeMatch(property.PropertyType, typeof(string[])))
+								{
+									property.SetValue(settings, strValueArr);
+								}
+
+								else if (TypeMatch(property.PropertyType, typeof(bool), typeof(bool?)))
+								{
+									if (bool.TryParse(strValueArr.FirstOrDefault(), out bool value))
+									{
+										property.SetValue(settings, value);
+									}
+								}
+								else if (TypeMatch(property.PropertyType, typeof(bool[]), typeof(bool?[])))
+								{
+									var arr = strValueArr.Where(x => bool.TryParse(x, out var _)).Select(x => bool.Parse(x));
+									if (arr.Any()) property.SetValue(settings, arr);
+								}
+
+								else if (TypeMatch(property.PropertyType, typeof(int), typeof(int?)))
+								{
+									if (int.TryParse(strValueArr.FirstOrDefault(), out var value))
+									{
+										property.SetValue(settings, value);
+									}
+								}
+								else if (TypeMatch(property.PropertyType, typeof(int[]), typeof(int?[])))
+								{
+									var arr = strValueArr.Where(x => int.TryParse(x, out var _)).Select(x => int.Parse(x));
+									if (arr.Any()) property.SetValue(settings, arr);
+								}
+
+								else if (TypeMatch(property.PropertyType, typeof(short), typeof(short?)))
+								{
+									if (short.TryParse(strValueArr.FirstOrDefault(), out var vaue))
+									{
+										property.SetValue(settings, vaue);
+									}
+								}
+								else if (TypeMatch(property.PropertyType, typeof(short[]), typeof(short?[])))
+								{
+									var arr = strValueArr.Where(x => short.TryParse(x, out var _)).Select(x => short.Parse(x));
+									if (arr.Any()) property.SetValue(settings, arr);
+								}
+
+								else if (TypeMatch(property.PropertyType, typeof(long), typeof(long?)))
+								{
+									if (long.TryParse(strValueArr.FirstOrDefault(), out var value))
+									{
+										property.SetValue(settings, value);
+									}
+								}
+								else if (TypeMatch(property.PropertyType, typeof(long[]), typeof(long?[])))
+								{
+									var arr = strValueArr.Where(x => long.TryParse(x, out var _)).Select(x => long.Parse(x));
+									if (arr.Any()) property.SetValue(settings, arr);
+								}
+
+								else if (TypeMatch(property.PropertyType, typeof(decimal), typeof(decimal?)))
+								{
+									if (decimal.TryParse(strValueArr.FirstOrDefault(), out var value))
+									{
+										property.SetValue(settings, value);
+									}
+								}
+								else if (TypeMatch(property.PropertyType, typeof(decimal[]), typeof(decimal?[])))
+								{
+									var arr = strValueArr.Where(x => decimal.TryParse(x, out var _)).Select(x => decimal.Parse(x));
+									if (arr.Any()) property.SetValue(settings, arr);
+								}
+
+								else if (TypeMatch(property.PropertyType, typeof(double), typeof(double?)))
+								{
+									if (double.TryParse(strValueArr.FirstOrDefault(), out var value))
+									{
+										property.SetValue(settings, value);
+									}
+								}
+								else if (TypeMatch(property.PropertyType, typeof(double[]), typeof(double?[])))
+								{
+									var arr = strValueArr.Where(x => double.TryParse(x, out var _)).Select(x => double.Parse(x));
+									if (arr.Any()) property.SetValue(settings, arr);
+								}
+
+								else if (TypeMatch(property.PropertyType, typeof(float), typeof(float?)))
+								{
+									if (float.TryParse(strValueArr.FirstOrDefault(), out var value))
+									{
+										property.SetValue(settings, value);
+									}
+								}
+								else if (TypeMatch(property.PropertyType, typeof(float[]), typeof(float?[])))
+								{
+									var arr = strValueArr.Where(x => float.TryParse(x, out var _)).Select(x => float.Parse(x));
+									if (arr.Any()) property.SetValue(settings, arr);
+								}
+
+								else if (TypeMatch(property.PropertyType, typeof(char), typeof(char?)))
+								{
+									if (char.TryParse(strValueArr.FirstOrDefault(), out var value))
+									{
+										property.SetValue(settings, value);
+									}
+								}
+								else if (TypeMatch(property.PropertyType, typeof(char[]), typeof(char?[])))
+								{
+									var arr = strValueArr.Where(x => char.TryParse(x, out var _)).Select(x => char.Parse(x));
+									if (arr.Any()) property.SetValue(settings, arr);
+								}
+
+								else
+								{
+									throw new Exception($"Cannot handle '{property.PropertyType.Name}' yet");
+								}
+							}
+							catch (Exception exception)
+							{
+								Logger.Log($"Failed to override '{property.Name}' setting", exception);
+							}
+						}
+					}
+				}
+				return settings;
+			}
+		}
 		public string CoverageOutputFolder { get; set; }
-		public XElement ProjectFileXElement { get; set; }
+		private XElement projectFileXElement;
+		public XElement ProjectFileXElement
+		{
+			get
+			{
+				if(projectFileXElement == null)
+                {
+					projectFileXElement = XElementUtil.Load(ProjectFile, true);
+				}
+				return projectFileXElement;
+
+			}
+		}
 		public List<ReferencedProject> ReferencedProjects { get; set; }
-		public bool HasExcludeFromCodeCoverageAssemblyAttribute { get; set; }
 		public string AssemblyName { get; set; }
 		public bool Is64Bit { get; set; }
 		public string RunSettingsFile { get; set; }
 
-        public CoverageProject Step(string stepName, Action<CoverageProject> action)
+        public async Task<CoverageProject> StepAsync(string stepName, Func<CoverageProject, System.Threading.Tasks.Task> action)
 		{
 			if (HasFailed)
 			{
@@ -48,7 +322,7 @@ namespace FineCodeCoverage.Engine.Model
 
 			try
 			{
-				action(this);
+				await action(this);
 			}
 			catch (Exception exception)
 			{
@@ -64,13 +338,30 @@ namespace FineCodeCoverage.Engine.Model
 			return this;
 		}
 
-		internal void PrepareForCoverage()
+		internal async System.Threading.Tasks.Task PrepareForCoverageAsync(DTE dte)
         {
 			SetPaths();
 			EnsureDirectories();
 			CleanDirectory();
 			SynchronizeBuildOutput();
+			await SetAssemblyNameAndReferencedProjectsAsync(dte);
         }
+
+		private async System.Threading.Tasks.Task SetAssemblyNameAndReferencedProjectsAsync(DTE dte)
+		{
+			await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+			var project = dte.Solution.Projects.Cast<Project>().First(p =>
+			{
+				ThreadHelper.ThrowIfNotOnUIThread();
+				return p.FullName == ProjectFile;
+			});
+			AssemblyName = (string)project.Properties.Item("AssemblyName").Value;
+			var vsproject = project.Object as VSLangProj.VSProject;
+			ReferencedProjects = vsproject.References.Cast<VSLangProj.Reference>().Where(r => r.SourceProject != null).Select(r=>new ReferencedProject(r)).ToList();
+		}
+		
+
 
 		private void SetPaths()
         {

--- a/FineCodeCoverage/Core/Model/ReferencedProject.cs
+++ b/FineCodeCoverage/Core/Model/ReferencedProject.cs
@@ -1,14 +1,23 @@
-﻿using System.IO;
-using System.Xml.Linq;
+﻿using FineCodeCoverage.Core.Utilities;
+using FineCodeCoverage.Engine;
+using System.IO;
+using VSLangProj;
 
 namespace FineCodeCoverage.Core.Model
 {
 	internal class ReferencedProject
 	{
-		public string ProjectFile { get; set; }
-		public string AssemblyName { get; set; }
-		public XElement ProjectFileXElement { get; internal set; }
-		public string ProjectFolder => Path.GetDirectoryName(ProjectFile);
-		public bool HasExcludeFromCodeCoverageAssemblyAttribute { get; set; }
+        public ReferencedProject(Reference reference)
+        {
+            Microsoft.VisualStudio.Shell.ThreadHelper.ThrowIfNotOnUIThread();
+            var referenceProjectPath = reference.SourceProject.FullName;
+			var projectFileXElement = XElementUtil.Load(referenceProjectPath, true);
+
+			HasExcludeFromCodeCoverageAssemblyAttribute = FCCEngine.HasExcludeFromCodeCoverageAssemblyAttribute(projectFileXElement);
+			AssemblyName = Path.GetFileNameWithoutExtension(reference.Path);
+		}
+
+		public string AssemblyName { get; private set; }
+		public bool HasExcludeFromCodeCoverageAssemblyAttribute { get; private set; }
 	}
 }

--- a/FineCodeCoverage/Core/OpenCover/OpenCoverUtil.cs
+++ b/FineCodeCoverage/Core/OpenCover/OpenCoverUtil.cs
@@ -9,6 +9,7 @@ using FineCodeCoverage.Engine.Model;
 using System.Diagnostics.CodeAnalysis;
 using FineCodeCoverage.Engine.Utilities;
 using FineCodeCoverage.Engine.MsTestPlatform;
+using System.Threading.Tasks;
 
 namespace FineCodeCoverage.Engine.OpenCover
 {
@@ -142,8 +143,7 @@ namespace FineCodeCoverage.Engine.OpenCover
 
 
 
-		[SuppressMessage("Usage", "VSTHRD002:Avoid problematic synchronous waits")]
-		public static bool RunOpenCover(CoverageProject project, bool throwError = false)
+		public static async Task<bool> RunOpenCoverAsync(CoverageProject project, bool throwError = false)
 		{
 			var title = $"OpenCover Run ({project.ProjectName})";
 
@@ -281,15 +281,14 @@ namespace FineCodeCoverage.Engine.OpenCover
 
 			Logger.Log($"{title} Arguments {Environment.NewLine}{string.Join($"{Environment.NewLine}", opencoverSettings)}");
 
-			var result = ProcessUtil
+			var result = await ProcessUtil
 			.ExecuteAsync(new ExecuteRequest
 			{
 				FilePath = OpenCoverExePath,
 				Arguments = string.Join(" ", opencoverSettings),
 				WorkingDirectory = project.ProjectOutputFolder
-			})
-			.GetAwaiter()
-			.GetResult();
+			});
+			
 			if(result != null)
             {
 				if (result.ExitCode != 0)

--- a/FineCodeCoverage/Core/SVsColorThemeService.cs
+++ b/FineCodeCoverage/Core/SVsColorThemeService.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+
+namespace FineCodeCoverage.Engine
+{
+    [Guid("0D915B59-2ED7-472A-9DE8-9161737EA1C5")]
+    [SuppressMessage("Style", "IDE1006:Naming Styles")]
+    public interface SVsColorThemeService
+    {
+    }
+}

--- a/FineCodeCoverage/FineCodeCoverage.csproj
+++ b/FineCodeCoverage/FineCodeCoverage.csproj
@@ -66,11 +66,13 @@
     <Compile Include="Core\Cobertura\Package.cs" />
     <Compile Include="Core\Cobertura\Packages.cs" />
     <Compile Include="Core\Cobertura\Sources.cs" />
+    <Compile Include="Core\CoverageUIEvents.cs" />
     <Compile Include="Core\Coverlet\CoverletUtil.cs" />
     <Compile Include="Core\FileSynchronization\FileSynchronization.cs" />
     <Compile Include="Core\Model\ReferencedProject.cs" />
     <Compile Include="Core\MsTestPlatform\MsTestPlatformUtil.cs" />
     <Compile Include="Core\ReportGenerator\ReportGeneratorUtil.cs" />
+    <Compile Include="Core\SVsColorThemeService.cs" />
     <Compile Include="Core\Utilities\AssemblyUtil.cs" />
     <Compile Include="Core\Model\CoverageLine.cs" />
     <Compile Include="Core\Model\CoverageProject.cs" />
@@ -177,7 +179,9 @@
     <PackageReference Include="Microsoft.TestPlatform.TestHost">
       <Version>16.7.0</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.205" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.206" ExcludeAssets="runtime">
+      <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.TestWindow.Interfaces">
       <Version>11.0.61030</Version>
     </PackageReference>

--- a/FineCodeCoverage/Impl/Tagger.cs
+++ b/FineCodeCoverage/Impl/Tagger.cs
@@ -14,10 +14,10 @@ namespace FineCodeCoverage.Impl
 		public Tagger(ITextBuffer textBuffer)
 		{
 			_textBuffer = textBuffer;
-			TestContainerDiscoverer.UpdateMarginTags += TestContainerDiscoverer_UpdateMarginTags;
+			FCCEngine.UpdateMarginTags += TestContainerDiscoverer_UpdateMarginTags;
 		}
 
-		private void TestContainerDiscoverer_UpdateMarginTags(object sender, UpdateMarginTagsEventArgs e)
+		private void TestContainerDiscoverer_UpdateMarginTags(UpdateMarginTagsEventArgs e)
 		{
 			var span = new SnapshotSpan(_textBuffer.CurrentSnapshot, 0, _textBuffer.CurrentSnapshot.Length);
 			var spanEventArgs = new SnapshotSpanEventArgs(span);

--- a/FineCodeCoverage/Impl/TestContainerDiscovery/TestContainerDiscoverer.cs
+++ b/FineCodeCoverage/Impl/TestContainerDiscovery/TestContainerDiscoverer.cs
@@ -51,7 +51,7 @@ namespace FineCodeCoverage.Impl
 				{		
 					Logger.Initialize(_serviceProvider);
 
-					FCCEngine.Initialize();
+					FCCEngine.Initialize(_serviceProvider);
 					Initialize(_serviceProvider);
 					TestContainersUpdated.ToString();
 					operationState.StateChanged += OperationState_StateChanged;
@@ -136,7 +136,7 @@ namespace FineCodeCoverage.Impl
 
 					var darkMode = CurrentTheme.Equals("Dark", StringComparison.OrdinalIgnoreCase);
 
-					CoverageProject[] projects = null;
+					List<CoverageProject> projects = null;
 					try
 					{
 						var testConfiguration = new Operation(e.Operation).Configuration;
@@ -144,7 +144,7 @@ namespace FineCodeCoverage.Impl
 						var userRunSettings = testConfiguration.UserRunSettings;
 						var runSettingsRetriever = new RunSettingsRetriever();
 						var testContainers = testConfiguration.Containers;
-
+						
 						projects = testConfiguration.Containers.Select(container =>
 						{
 							var project = new CoverageProject();
@@ -156,13 +156,12 @@ namespace FineCodeCoverage.Impl
 							project.ProjectFile = container.ProjectData.ProjectFilePath;
 							project.RunSettingsFile = ThreadHelper.JoinableTaskFactory.Run(() => runSettingsRetriever.GetRunSettingsFileAsync(userRunSettings, containerData));
 							return project;
-						}).ToArray();
+						}).ToList();
 
 					}catch(Exception exc)
                     {
 						throw new Exception("Error test container discoverer reflection",exc);
                     }
-					
 
 					_reloadCoverageThread = new Thread(() =>
 					{

--- a/FineCodeCoverage/Impl/TestContainerDiscovery/TestContainerDiscoverer.cs
+++ b/FineCodeCoverage/Impl/TestContainerDiscovery/TestContainerDiscoverer.cs
@@ -1,145 +1,146 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Threading;
-using FineCodeCoverage.Output;
 using FineCodeCoverage.Engine;
-using System.Collections.Generic;
-using Microsoft.VisualStudio.Shell;
 using FineCodeCoverage.Engine.Model;
-using System.Diagnostics.CodeAnalysis;
-using Microsoft.VisualStudio.Utilities;
-using System.ComponentModel.Composition;
+using FineCodeCoverage.Output;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TestWindow.Extensibility;
+using Microsoft.VisualStudio.Utilities;
 
 namespace FineCodeCoverage.Impl
 {
     [Name(Vsix.TestContainerDiscovererName)]
-	[Export(typeof(TestContainerDiscoverer))]
-	[Export(typeof(ITestContainerDiscoverer))]
-	internal class TestContainerDiscoverer : ITestContainerDiscoverer
-	{
+    [Export(typeof(TestContainerDiscoverer))]
+    [Export(typeof(ITestContainerDiscoverer))]
+    internal class TestContainerDiscoverer : ITestContainerDiscoverer
+    {
 #pragma warning disable 67
-		public event EventHandler TestContainersUpdated;
+        public event EventHandler TestContainersUpdated;
 #pragma warning restore 67
-		private readonly IServiceProvider _serviceProvider;
-		public Uri ExecutorUri => new Uri($"executor://{Vsix.Code}.Executor/v1");
-		public IEnumerable<ITestContainer> TestContainers => Enumerable.Empty<ITestContainer>();
-		
+        private readonly IServiceProvider _serviceProvider;
+        public Uri ExecutorUri => new Uri($"executor://{Vsix.Code}.Executor/v1");
+        public IEnumerable<ITestContainer> TestContainers => Enumerable.Empty<ITestContainer>();
 
-		[ImportingConstructor]
-		internal TestContainerDiscoverer
-		(
-			[Import(typeof(IOperationState))]
-			IOperationState operationState,
 
-			[Import(typeof(SVsServiceProvider))]
-			IServiceProvider serviceProvider
-		)
-		{
-			_serviceProvider = serviceProvider;
+        [ImportingConstructor]
+        internal TestContainerDiscoverer
+        (
+            [Import(typeof(IOperationState))]
+            IOperationState operationState,
 
-			new Thread(() =>
-			{
-				try
-				{		
-					Logger.Initialize(_serviceProvider);
+            [Import(typeof(SVsServiceProvider))]
+            IServiceProvider serviceProvider
+        )
+        {
+            _serviceProvider = serviceProvider;
 
-					FCCEngine.Initialize(_serviceProvider);
-					Initialize(_serviceProvider);
-					operationState.StateChanged += OperationState_StateChanged;
+            new Thread(() =>
+            {
+                try
+                {
+                    Logger.Initialize(_serviceProvider);
 
-					Logger.Log($"Initialized");
-				}
-				catch (Exception exception)
-				{
-					Logger.Log($"Failed Initialization", exception);
-				}
-			}).Start();
-		}
+                    FCCEngine.Initialize(_serviceProvider);
+                    Initialize(_serviceProvider);
+                    operationState.StateChanged += OperationState_StateChanged;
 
-		[SuppressMessage("Usage", "VSTHRD102:Implement internal logic asynchronously")]
-		private void Initialize(IServiceProvider serviceProvider)
-		{
-			ThreadHelper.JoinableTaskFactory.Run(async () =>
-			{
-				await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    Logger.Log($"Initialized");
+                }
+                catch (Exception exception)
+                {
+                    Logger.Log($"Failed Initialization", exception);
+                }
+            }).Start();
+        }
 
-				if (serviceProvider.GetService(typeof(SVsShell)) is IVsShell shell)
-				{
-					var packageToBeLoadedGuid = new Guid(OutputToolWindowPackage.PackageGuidString);
-					shell.LoadPackage(ref packageToBeLoadedGuid, out var package);
+        [SuppressMessage("Usage", "VSTHRD102:Implement internal logic asynchronously")]
+        private void Initialize(IServiceProvider serviceProvider)
+        {
+            ThreadHelper.JoinableTaskFactory.Run(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-					var outputWindowInitializedFile = Path.Combine(FCCEngine.AppDataFolder, "outputWindowInitialized");
+                if (serviceProvider.GetService(typeof(SVsShell)) is IVsShell shell)
+                {
+                    var packageToBeLoadedGuid = new Guid(OutputToolWindowPackage.PackageGuidString);
+                    shell.LoadPackage(ref packageToBeLoadedGuid, out var package);
 
-					if (File.Exists(outputWindowInitializedFile))
-					{
-						OutputToolWindowCommand.Instance.FindToolWindow();
-					}
-					else
-					{
-						// for first time users, the window is automatically docked 
-						OutputToolWindowCommand.Instance.ShowToolWindow();
-						File.WriteAllText(outputWindowInitializedFile, string.Empty);
-					}
-				}
-			});
-		}
+                    var outputWindowInitializedFile = Path.Combine(FCCEngine.AppDataFolder, "outputWindowInitialized");
 
-		private void OperationState_StateChanged(object sender, OperationStateChangedEventArgs e)
-		{
-			try
-			{
-				if (e.State == TestOperationStates.TestExecutionStarting)
-				{
-					FCCEngine.StopCoverage();
-				}
+                    if (File.Exists(outputWindowInitializedFile))
+                    {
+                        OutputToolWindowCommand.Instance.FindToolWindow();
+                    }
+                    else
+                    {
+                        // for first time users, the window is automatically docked 
+                        OutputToolWindowCommand.Instance.ShowToolWindow();
+                        File.WriteAllText(outputWindowInitializedFile, string.Empty);
+                    }
+                }
+            });
+        }
 
-				if (e.State == TestOperationStates.TestExecutionFinished)
-				{
+        private void OperationState_StateChanged(object sender, OperationStateChangedEventArgs e)
+        {
+            try
+            {
+                if (e.State == TestOperationStates.TestExecutionStarting)
+                {
+                    FCCEngine.StopCoverage();
+                }
+
+                if (e.State == TestOperationStates.TestExecutionFinished)
+                {
                     if (!FCCEngine.CanRunCoverage())
                     {
-						return;
+                        return;
                     }
 
-					List<CoverageProject> projects = null;
-					try
-					{
-						var testConfiguration = new Operation(e.Operation).Configuration;
-
-						var userRunSettings = testConfiguration.UserRunSettings;
-						var runSettingsRetriever = new RunSettingsRetriever();
-						var testContainers = testConfiguration.Containers;
-						
-						projects = testConfiguration.Containers.Select(container =>
-						{
-							var project = new CoverageProject();
-							project.ProjectName = container.ProjectName;
-							project.TestDllFile = container.Source;
-							project.Is64Bit = container.TargetPlatform.ToString().ToLower().Equals("x64");
-
-							var containerData = container.ProjectData;
-							project.ProjectFile = container.ProjectData.ProjectFilePath;
-							project.RunSettingsFile = ThreadHelper.JoinableTaskFactory.Run(() => runSettingsRetriever.GetRunSettingsFileAsync(userRunSettings, containerData));
-							return project;
-						}).ToList();
-
-					}catch(Exception exc)
+                    List<CoverageProject> projects = null;
+                    try
                     {
-						throw new Exception("Error test container discoverer reflection",exc);
+                        var testConfiguration = new Operation(e.Operation).Configuration;
+
+                        var userRunSettings = testConfiguration.UserRunSettings;
+                        var runSettingsRetriever = new RunSettingsRetriever();
+                        var testContainers = testConfiguration.Containers;
+
+                        projects = testConfiguration.Containers.Select(container =>
+                        {
+                            var project = new CoverageProject();
+                            project.ProjectName = container.ProjectName;
+                            project.TestDllFile = container.Source;
+                            project.Is64Bit = container.TargetPlatform.ToString().ToLower().Equals("x64");
+
+                            var containerData = container.ProjectData;
+                            project.ProjectFile = container.ProjectData.ProjectFilePath;
+                            project.RunSettingsFile = ThreadHelper.JoinableTaskFactory.Run(() => runSettingsRetriever.GetRunSettingsFileAsync(userRunSettings, containerData));
+                            return project;
+                        }).ToList();
+
+                    }
+                    catch (Exception exc)
+                    {
+                        throw new Exception("Error test container discoverer reflection", exc);
                     }
 
-					FCCEngine.ReloadCoverage(projects);
-				}
-			}
-			catch (Exception exception)
-			{
-				Logger.Log("Error processing unit test events", exception);
-			}
-		}
-	}
+                    FCCEngine.ReloadCoverage(projects);
+                }
+            }
+            catch (Exception exception)
+            {
+                Logger.Log("Error processing unit test events", exception);
+            }
+        }
+    }
 
-	
-	
+
+
 }

--- a/FineCodeCoverage/Output/OutputToolWindowControl.xaml.cs
+++ b/FineCodeCoverage/Output/OutputToolWindowControl.xaml.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.Shell;
 using System.Runtime.InteropServices;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Microsoft;
 
 namespace FineCodeCoverage.Output
 {
@@ -33,7 +34,7 @@ namespace FineCodeCoverage.Output
 			{
 				await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 				Dte = (DTE)await OutputToolWindowCommand.Instance.ServiceProvider.GetServiceAsync(typeof(DTE));
-
+				Assumes.Present(Dte);
 				Events = Dte.Events;
 				SolutionEvents = Events.SolutionEvents;
 				SolutionEvents.Opened += () => Clear();
@@ -43,7 +44,7 @@ namespace FineCodeCoverage.Output
 			ScriptManager = new ScriptManager(Dte);
 			FCCOutputBrowser.ObjectForScripting = ScriptManager;
 			
-			TestContainerDiscoverer.UpdateOutputWindow += (sender, args) =>
+			FCCEngine.UpdateOutputWindow += (args) =>
 			{
 				ThreadHelper.JoinableTaskFactory.Run(async () =>
 				{


### PR DESCRIPTION
fixes #73 

Note that there are warnings for 'should only be done on the main thread' for the method PrepareProjectsOnUIThread that is done on the main thread.

