### PR TITLE
clear ui when start run coverage

### DIFF
--- a/FineCodeCoverage/Core/FCCEngine.cs
+++ b/FineCodeCoverage/Core/FCCEngine.cs
@@ -118,6 +118,7 @@ namespace FineCodeCoverage.Engine
         
         private CancellationToken Reset()
         {
+            ClearUI();
             StopCoverage();
 
             cancellationTokenSource = new CancellationTokenSource();
@@ -240,7 +241,7 @@ namespace FineCodeCoverage.Engine
                 case System.Threading.Tasks.TaskStatus.Faulted:
                     LogReloadCoverageStatus(ReloadCoverageStatus.Error);
                     logger.Log(t.Exception.InnerExceptions[0]);
-                    UpdateUI(null, null);
+                    ClearUI();
                     break;
                 case System.Threading.Tasks.TaskStatus.RanToCompletion:
                     LogReloadCoverageStatus(ReloadCoverageStatus.Done);

--- a/FineCodeCoverageTests/FCCEngine_Tests.cs
+++ b/FineCodeCoverageTests/FCCEngine_Tests.cs
@@ -344,7 +344,7 @@ namespace Test
         public async Task Should_Clear_UI_Then_Update_UI_When_ReloadCoverage_Completes_Fully()
         {
             fccEngine.CoverageLines = new List<CoverageLine>();
-            var (updatedCoverageLines, reportGeneratedHtmlContent) = await RunToCompletion(false);
+            var (reportGeneratedHtmlContent, updatedCoverageLines) = await RunToCompletion(false);
 
             VerifyLogsReloadCoverageStatus(ReloadCoverageStatus.Done);
 


### PR DESCRIPTION
As suggested by #132 the gutters and report is updating when coverage completes but was not clearing when coverage starting.