### PR TITLE
fix

### DIFF
--- a/FineCodeCoverage/Core/ReportGenerator/ReportGeneratorUtil.cs
+++ b/FineCodeCoverage/Core/ReportGenerator/ReportGeneratorUtil.cs
@@ -91,21 +91,22 @@ namespace FineCodeCoverage.Engine.ReportGenerator
 				{
 					reportTypeSettings.Add($@"""-reports:{inputReports}""");
 					reportTypeSettings.Add($@"""-reporttypes:Cobertura""");
-					var options = appOptionsProvider.Get();
-					var cyclomaticThreshold = options.ThresholdForCyclomaticComplexity;
-					var crapScoreThreshold = options.ThresholdForCrapScore;
-					var nPathThreshold = options.ThresholdForNPathComplexity;
 					
-					reportTypeSettings.Add($@"""-riskHotspotsAnalysisThresholds:metricThresholdForCyclomaticComplexity={cyclomaticThreshold}""");
-					reportTypeSettings.Add($@"""-riskHotspotsAnalysisThresholds:metricThresholdForCrapScore={crapScoreThreshold}""");
-					reportTypeSettings.Add($@"""-riskHotspotsAnalysisThresholds:metricThresholdForNPathComplexity={nPathThreshold}""");
-
 				}
 				else if (outputReportType.Equals("HtmlInline_AzurePipelines", StringComparison.OrdinalIgnoreCase))
 				{
 					reportTypeSettings.Add($@"""-reports:{inputReports}""");
 					reportTypeSettings.Add($@"""-plugins:{typeof(FccLightReportBuilder).Assembly.Location}""");
 					reportTypeSettings.Add($@"""-reporttypes:{(darkMode ? FccDarkReportBuilder.REPORT_TYPE : FccLightReportBuilder.REPORT_TYPE)}""");
+					var options = appOptionsProvider.Get();
+					var cyclomaticThreshold = options.ThresholdForCyclomaticComplexity;
+					var crapScoreThreshold = options.ThresholdForCrapScore;
+					var nPathThreshold = options.ThresholdForNPathComplexity;
+
+					reportTypeSettings.Add($@"""riskHotspotsAnalysisThresholds:metricThresholdForCyclomaticComplexity={cyclomaticThreshold}""");
+					reportTypeSettings.Add($@"""riskHotspotsAnalysisThresholds:metricThresholdForCrapScore={crapScoreThreshold}""");
+					reportTypeSettings.Add($@"""riskHotspotsAnalysisThresholds:metricThresholdForNPathComplexity={nPathThreshold}""");
+
 				}
 				else
 				{

--- a/FineCodeCoverage/Core/ReportGenerator/ReportGeneratorUtil.cs
+++ b/FineCodeCoverage/Core/ReportGenerator/ReportGeneratorUtil.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using FineCodeCoverage.Core.Utilities;
+using FineCodeCoverage.Options;
 using Fizzler.Systems.HtmlAgilityPack;
 using HtmlAgilityPack;
 using Newtonsoft.Json;
@@ -38,7 +39,8 @@ namespace FineCodeCoverage.Engine.ReportGenerator
         private readonly IToolFolder toolFolder;
         private readonly IToolZipProvider toolZipProvider;
 		private readonly IFileUtil fileUtil;
-		private const string zipPrefix = "reportGenerator";
+        private readonly IAppOptionsProvider appOptionsProvider;
+        private const string zipPrefix = "reportGenerator";
 		private const string zipDirectoryName = "reportGenerator";
 
         public string ReportGeneratorExePath { get; private set; }
@@ -50,10 +52,12 @@ namespace FineCodeCoverage.Engine.ReportGenerator
 			ILogger logger,
 			IToolFolder toolFolder,
 			IToolZipProvider toolZipProvider,
-			IFileUtil fileUtil
+			IFileUtil fileUtil,
+			IAppOptionsProvider appOptionsProvider
 			)
 		{
 			this.fileUtil = fileUtil;
+            this.appOptionsProvider = appOptionsProvider;
             this.assemblyUtil = assemblyUtil;
             this.processUtil = processUtil;
             this.logger = logger;
@@ -87,6 +91,15 @@ namespace FineCodeCoverage.Engine.ReportGenerator
 				{
 					reportTypeSettings.Add($@"""-reports:{inputReports}""");
 					reportTypeSettings.Add($@"""-reporttypes:Cobertura""");
+					var options = appOptionsProvider.Get();
+					var cyclomaticThreshold = options.ThresholdForCyclomaticComplexity;
+					var crapScoreThreshold = options.ThresholdForCrapScore;
+					var nPathThreshold = options.ThresholdForNPathComplexity;
+					
+					reportTypeSettings.Add($@"""-riskHotspotsAnalysisThresholds:metricThresholdForCyclomaticComplexity={cyclomaticThreshold}""");
+					reportTypeSettings.Add($@"""-riskHotspotsAnalysisThresholds:metricThresholdForCrapScore={crapScoreThreshold}""");
+					reportTypeSettings.Add($@"""-riskHotspotsAnalysisThresholds:metricThresholdForNPathComplexity={nPathThreshold}""");
+
 				}
 				else if (outputReportType.Equals("HtmlInline_AzurePipelines", StringComparison.OrdinalIgnoreCase))
 				{

--- a/FineCodeCoverage/Core/ReportGenerator/ReportGeneratorUtil.cs
+++ b/FineCodeCoverage/Core/ReportGenerator/ReportGeneratorUtil.cs
@@ -407,14 +407,16 @@ namespace FineCodeCoverage.Engine.ReportGenerator
 							{ button: 'btnRiskHotspots', content: 'risk-hotspots' },
 						];
 
+						var riskHotspotsTable;
+						var riskHotspotsElement;
 						var addedFileIndexToRiskHotspots = false;
 						var addFileIndexToRiskHotspotsClassLink = function(){
 						  if(!addedFileIndexToRiskHotspots){
 							addedFileIndexToRiskHotspots = true;
 							var riskHotspotsElements = document.getElementsByTagName('risk-hotspots');
 							if(riskHotspotsElements.length == 1){{
-								var riskHotspotsElement = riskHotspotsElements[0];
-								var riskHotspotsTable = riskHotspotsElement.querySelector('table');
+								riskHotspotsElement = riskHotspotsElements[0];
+								riskHotspotsTable = riskHotspotsElement.querySelector('table');
 								if(riskHotspotsTable){
 									var rhBody = riskHotspotsTable.querySelector('tbody');
 									var rows = rhBody.rows;
@@ -439,10 +441,40 @@ namespace FineCodeCoverage.Engine.ReportGenerator
 							}}
 							}
 						}
+						
+						// necessary for WebBrowser 
+						function removeElement(element){
+							element.parentNode.removeChild(element);
+						}
 
-	var openTab = function (tabIndex) {
+						function insertAfter(newNode, existingNode) {
+							existingNode.parentNode.insertBefore(newNode, existingNode.nextSibling);
+						}
+
+						var noHotspotsMessage
+						var addNoRiskHotspotsMessageIfRequired = function(){
+							if(riskHotspotsTable == null){
+								noHotspotsMessage = document.createElement(""p"");
+								noHotspotsMessage.style.margin = ""0"";
+								noHotspotsMessage.innerText = ""No risk hotspots found."";
+
+								insertAfter(noHotspotsMessage, riskHotspotsElement);
+							}
+						}
+
+						var removeNoRiskHotspotsMessage = function(){
+							if(noHotspotsMessage){
+								removeElement(noHotspotsMessage);
+								noHotspotsMessage = null;
+							}
+						}
+
+						var openTab = function (tabIndex) {
 							if(tabIndex==2){{
 								addFileIndexToRiskHotspotsClassLink();
+								addNoRiskHotspotsMessageIfRequired();
+							}}else{{
+								removeNoRiskHotspotsMessage();
 							}}
 							for (var i = 0; i < tabs.length; i++) {
 							

--- a/FineCodeCoverage/Options/AppOptions.cs
+++ b/FineCodeCoverage/Options/AppOptions.cs
@@ -140,13 +140,15 @@ namespace FineCodeCoverage.Options
 
         [Category(reportCategory)]
         [Description("When cyclomatic complexity exceeds this value for a method then the method will be present in the risk hotspots tab.")]
-        public int ThresholdForCyclomaticComplexity { get; set; } = 30
+        public int ThresholdForCyclomaticComplexity { get; set; } = 30;
+
         [Category(reportCategory)]
         [Description("When npath complexity exceeds this value for a method then the method will be present in the risk hotspots tab. OpenCover only")]
-        public int ThresholdForNPathComplexity { get; set; } = 200
+        public int ThresholdForNPathComplexity { get; set; } = 200;
+        
         [Category(reportCategory)]
         [Description("When crap score exceeds this value for a method then the method will be present in the risk hotspots tab. OpenCover only")]
-        public int ThresholdForCrapScore { get; set; } = 15
+        public int ThresholdForCrapScore { get; set; } = 15;
 
         [SuppressMessage("Usage", "VSTHRD010:Invoke single-threaded types on Main thread")]
         public override void SaveSettingsToStorage()

--- a/FineCodeCoverage/Options/AppOptions.cs
+++ b/FineCodeCoverage/Options/AppOptions.cs
@@ -13,6 +13,7 @@ namespace FineCodeCoverage.Options
         private const string coverletCategory = "Coverlet";
         private const string openCoverCategory = "OpenCover";
         private const string outputCategory = "Output";
+        private const string reportCategory = "Report";
 
         public AppOptions():this(false)
         {
@@ -136,6 +137,16 @@ namespace FineCodeCoverage.Options
         [Description("To have fcc output visible in a sub folder of your solution provide this name")]
         [Category(outputCategory)]
         public string FCCSolutionOutputDirectoryName { get; set; }
+
+        [Category(reportCategory)]
+        [Description("When cyclomatic complexity exceeds this value for a method then the method will be present in the risk hotspots tab.")]
+        public int ThresholdForCyclomaticComplexity { get; set; } = 30
+        [Category(reportCategory)]
+        [Description("When npath complexity exceeds this value for a method then the method will be present in the risk hotspots tab. OpenCover only")]
+        public int ThresholdForNPathComplexity { get; set; } = 200
+        [Category(reportCategory)]
+        [Description("When crap score exceeds this value for a method then the method will be present in the risk hotspots tab. OpenCover only")]
+        public int ThresholdForCrapScore { get; set; } = 15
 
         [SuppressMessage("Usage", "VSTHRD010:Invoke single-threaded types on Main thread")]
         public override void SaveSettingsToStorage()

--- a/FineCodeCoverage/Options/IAppOptions.cs
+++ b/FineCodeCoverage/Options/IAppOptions.cs
@@ -18,5 +18,8 @@
         string CoverletCollectorDirectoryPath { get; }
         string OpenCoverCustomPath { get; }
         string FCCSolutionOutputDirectoryName { get; }
+        int ThresholdForCyclomaticComplexity { get; }
+        int ThresholdForNPathComplexity { get; }
+        int ThresholdForCrapScore { get; }
     }
 }

--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ ExcludeByFile					Glob patterns specifying source files to exclude e.g. **/Migra
 ExcludeByAttribute				Attributes to exclude from code coverage (multiple values)
 IncludeTestAssembly				Specifies whether to report code coverage of the test assembly
 
+ThresholdForCyclomaticComplexity When [cyclomatic complexity](https://en.wikipedia.org/wiki/Cyclomatic_complexity) exceeds this value for a method then the method will be present in the risk hotspots tab. 
+ThresholdForNPathComplexity     When [npath complexity](https://en.wikipedia.org/wiki/Cyclomatic_complexity) exceeds this value for a method then the method will be present in the risk hotspots tab. OpenCover only.
+ThresholdForCrapScore           When [crap score](https://testing.googleblog.com/2011/02/this-code-is-crap.html) exceeds this value for a method then the method will be present in the risk hotspots tab. OpenCover only. 
+
 RunSettingsOnly					Specify false for global and project options to be used for coverlet data collector configuration elements when not specified in runsettings
 CoverletCollectorDirectoryPath	Specify path to directory containing coverlet collector files if you need functionality that the FCC version does not provide.
 
@@ -138,6 +142,8 @@ You can ignore a method or an entire class from code coverage by creating and ap
 You can also ignore additional attributes by adding to the 'ExcludeByAttributes' list (short name or full name supported) e.g. :
 [GeneratedCode] => Present in System.CodeDom.Compiler namespace
 [MyCustomExcludeFromCodeCoverage] => Any custom attribute that you may define
+
+ 
 ```
 
 #### Filter Expressions


### PR DESCRIPTION
@FortuneN 

My laptop is in for repair and I am running visual studio on an Azure VM.  Unfortunately when debugging I am getting the following error ( one that probably does not occur outside the vm )

Fine Code Coverage : System.InvalidCastException: Unable to cast COM object of type 'System.__ComObject' to interface type 'Microsoft.VisualStudio.Shell.IVsAppId'. This operation failed because the QueryInterface call on the COM component for the interface with IID '{1EAA526A-0898-11D3-B868-00C04F79F802}' failed due to the following error: No such interface supported (Exception from HRESULT: 0x80004002 (E_NOINTERFACE)).
   at Microsoft.VisualStudio.PlatformUI.EnvironmentOptions.GeneralOptionsPage.ReadAppIdThemeOption(IVsColorThemes colorThemes)
   at Microsoft.VisualStudio.PlatformUI.EnvironmentOptions.GeneralOptionsPage.CalculateCurrentTheme(String themeProperty, IVsColorThemes colorThemes, Boolean shouldUseHighContrast, Boolean& success, Boolean& needSubscribeToThemeSettingEvents, ISettingsManager& settingsManager)
   at Microsoft.VisualStudio.Platform.WindowManagement.ColorThemeService.CalculateCurrentTheme(String themeProperty, IVsColorTheme& theme)
   at Microsoft.VisualStudio.Platform.WindowManagement.ColorThemeService.get_CurrentTheme()
   at CallSite.Target(Closure , CallSite , Object )
   at System.Dynamic.UpdateDelegates.UpdateAndExecute1[T0,TRet](CallSite site, T0 arg0)
   at FineCodeCoverage.Engine.FCCEngine.get_CurrentTheme() in C:\Users\tonyhallett\Source\Repos\FineCodeCoverage\FineCodeCoverage\Core\FCCEngine.cs:line 25
   at FineCodeCoverage.Engine.FCCEngine.<RunAndProcessReportAsync>d__45.MoveNext() in C:\Users\tonyhallett\Source\Repos\FineCodeCoverage\FineCodeCoverage\Core\FCCEngine.cs:line 165
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at FineCodeCoverage.Engine.FCCEngine.<>c__DisplayClass49_0.<<ReloadCoverage>b__0>d.MoveNext() in C:\Users\tonyhallett\Source\Repos\FineCodeCoverage\FineCodeCoverage\Core\FCCEngine.cs:line 267

Please can you check that this does not occur when FCC is run normally.
Note that the change in this pr is javascript only  - for issue - #160 