### PR TITLE
Configuration option for app data folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ but there may be a preview version that you want to use.  This can be configured
 Configuration is available with Visual Studio settings and project msbuild properties.  All visual studio settings can be overridden from test project settings and some settings 
 can only be set in project files.
 
+The coverage tools that FCC leverages are by default installed into the FineCodeCoverage directory within `Environment.SpecialFolder.LocalApplicationData`.
+This can be changed with the ToolsDirectory Visual Studio option.  Ensure that this containing directory exists and upon restart the tools will be installed within.
+
 ---
 
 ### <a href="https://www.youtube.com/watch?v=Rae5bTE2D3o" target="_blank">Watch Introduction Video</a>
@@ -145,6 +148,8 @@ CoverletConsoleGlobal			   Specify true to use your own dotnet tools global inst
 
 FCCSolutionOutputDirectoryName     To have fcc output visible in a sub folder of your solution provide this name
 AdjacentBuildOutput                If your tests are dependent upon their path set this to true.
+
+ToolsDirectory                     Folder to which copy tools subfolder. Must alredy exist. Requires restart of VS.
 
 The "CoverletConsole" settings have precedence Local / CustomPath / Global.
 

--- a/SharedProject/Core/AppDataFolder.cs
+++ b/SharedProject/Core/AppDataFolder.cs
@@ -3,6 +3,7 @@ using System.ComponentModel.Composition;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using FineCodeCoverage.Options;
 
 namespace FineCodeCoverage.Engine
 {
@@ -12,13 +13,15 @@ namespace FineCodeCoverage.Engine
     {
         private readonly ILogger logger;
         private readonly IEnvironmentVariable environmentVariable;
+        private readonly IAppOptionsProvider appOptionsProvider;
         internal const string fccDebugCleanInstallEnvironmentVariable = "FCCDebugCleanInstall";
 
         [ImportingConstructor]
-        public AppDataFolder(ILogger logger,IEnvironmentVariable environmentVariable)
+        public AppDataFolder(ILogger logger,IEnvironmentVariable environmentVariable, IAppOptionsProvider appOptionsProvider)
         {
             this.logger = logger;
             this.environmentVariable = environmentVariable;
+            this.appOptionsProvider = appOptionsProvider;
         }
         public string DirectoryPath { get; private set; }
 
@@ -34,7 +37,7 @@ namespace FineCodeCoverage.Engine
 
         private void CreateAppDataFolder()
         {
-            DirectoryPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), Vsix.Code);
+            DirectoryPath = Path.Combine(GetAppDataFolder(), Vsix.Code);
             if (environmentVariable.Get(fccDebugCleanInstallEnvironmentVariable) != null)
             {
                 logger.Log("FCCDebugCleanInstall");
@@ -56,6 +59,13 @@ namespace FineCodeCoverage.Engine
                 }
             }
             Directory.CreateDirectory(DirectoryPath);
+        }
+
+        private string GetAppDataFolder()
+        {
+            var dir = appOptionsProvider.Get().ToolsDirectory;
+
+            return Directory.Exists(dir) ? dir : Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
         }
 
         private void CleanupLegacyFolders()

--- a/SharedProject/Options/AppOptions.cs
+++ b/SharedProject/Options/AppOptions.cs
@@ -9,6 +9,7 @@ namespace FineCodeCoverage.Options
     internal class AppOptions : DialogPage, IAppOptions
     {
         private const string runCategory = "Run";
+        private const string environmentCategory = "Environment";
         private const string excludeIncludeCategory = "Exclude / Include";
         private const string coverletCategory = "Coverlet";
         private const string openCoverCategory = "OpenCover";
@@ -114,6 +115,10 @@ namespace FineCodeCoverage.Options
         [Description("Specify a value to only run coverage based upon the number of executing tests.  Cannot be used in conjunction with RunInParallel")]
         [Category(runCategory)]
         public int RunWhenTestsExceed { get; set; }
+
+        [Description("Folder to which copy tools subfolder. Must alredy exist. Requires restart of VS.")]
+        [Category(environmentCategory)]
+        public string ToolsDirectory { get; set; }
 
         [Description("Specify false for global and project options to be used for coverlet data collector configuration elements when not specified in runsettings")]
         [Category(coverletCategory)]

--- a/SharedProject/Options/IAppOptions.cs
+++ b/SharedProject/Options/IAppOptions.cs
@@ -10,6 +10,7 @@
         bool IncludeTestAssembly { get; }
         bool RunInParallel { get; }
         int RunWhenTestsExceed { get; }
+        string ToolsDirectory { get; }
         bool RunWhenTestsFail { get; }
         bool RunSettingsOnly { get; }
         bool CoverletConsoleGlobal { get; }


### PR DESCRIPTION
Some organizations allow execution of software form certain locations but not from others. New setting 'ToolDirectory' allows for configuration where FCC will store and execute it's tools.