### PR TITLE
Enable installation on Visual Studio 2022 for ARM64

### DIFF
--- a/FineCodeCoverage/FineCodeCoverage.csproj
+++ b/FineCodeCoverage/FineCodeCoverage.csproj
@@ -187,7 +187,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>13.0.1</Version>
+      <Version>13.0.3</Version>
     </PackageReference>
     <PackageReference Include="NUnit">
       <Version>3.13.1</Version>

--- a/FineCodeCoverage2022/FineCodeCoverage2022.csproj
+++ b/FineCodeCoverage2022/FineCodeCoverage2022.csproj
@@ -146,34 +146,34 @@
       <Version>1.4.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Common">
-      <Version>4.8.0</Version>
+      <Version>4.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp">
-      <Version>4.8.0</Version>
+      <Version>4.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.EditorFeatures.Text">
-      <Version>4.8.0</Version>
+      <Version>4.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic">
-      <Version>4.8.0</Version>
+      <Version>4.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common">
-      <Version>4.8.0</Version>
+      <Version>4.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild">
-      <Version>4.8.0</Version>
+      <Version>4.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Composition.Analyzers">
-      <Version>17.7.40</Version>
+      <Version>17.10.37</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.1.32210.191" ExcludeAssets="runtime">
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.10.40171" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.TestWindow.Interfaces">
       <Version>11.0.61030</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers">
-      <Version>17.9.28</Version>
+      <Version>17.10.48</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -182,7 +182,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>13.0.1</Version>
+      <Version>13.0.3</Version>
     </PackageReference>
     <PackageReference Include="ReflectObject">
       <Version>1.0.0</Version>
@@ -191,13 +191,13 @@
       <Version>1.0.0</Version>
     </PackageReference>
     <PackageReference Include="StreamJsonRpc">
-      <Version>2.16.36</Version>
+      <Version>2.18.48</Version>
     </PackageReference>
     <PackageReference Include="Svg">
       <Version>3.3.0</Version>
     </PackageReference>
     <PackageReference Include="System.Composition">
-      <Version>7.0.0</Version>
+      <Version>8.0.0</Version>
     </PackageReference>
     <PackageReference Include="System.IO.Compression">
       <Version>4.3.0</Version>

--- a/FineCodeCoverage2022/FineCodeCoverage2022.csproj
+++ b/FineCodeCoverage2022/FineCodeCoverage2022.csproj
@@ -177,7 +177,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.1.4054">
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.11.414">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/FineCodeCoverage2022/source.extension.vsixmanifest
+++ b/FineCodeCoverage2022/source.extension.vsixmanifest
@@ -13,6 +13,9 @@
         <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,18.0)">
             <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,18.0)">
+            <ProductArchitecture>arm64</ProductArchitecture>
+        </InstallationTarget>
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.7,)" />

--- a/FineCodeCoverageTests/FineCodeCoverageTests.csproj
+++ b/FineCodeCoverageTests/FineCodeCoverageTests.csproj
@@ -203,16 +203,16 @@
       <Version>1.2.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp">
-      <Version>4.8.0</Version>
+      <Version>4.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic">
-      <Version>4.8.0</Version>
+      <Version>4.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel">
       <Version>11.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK">
-      <Version>17.1.32210.191</Version>
+      <Version>17.10.40171</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.TestWindow.Interfaces">
       <Version>11.0.61030</Version>

--- a/FineCodeCoverageTests/app.config
+++ b/FineCodeCoverageTests/app.config
@@ -24,15 +24,15 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.VisualStudio.Threading" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-17.1.0.0" newVersion="17.7.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-17.10.0.0" newVersion="17.10.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
@@ -40,11 +40,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="StreamJsonRpc" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.8.0.0" newVersion="2.8.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.18.0.0" newVersion="2.18.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.VisualStudio.Validation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-17.0.0.0" newVersion="17.6.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-17.8.0.0" newVersion="17.8.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.VisualStudio.Shell.Interop" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -52,27 +52,27 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.8.0.0" newVersion="4.8.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.10.0.0" newVersion="4.10.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.8.0.0" newVersion="4.8.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.10.0.0" newVersion="4.10.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.VisualBasic" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.8.0.0" newVersion="4.8.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.10.0.0" newVersion="4.10.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.IO.Pipelines" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks.Dataflow" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>


### PR DESCRIPTION
This change adds support for the `arm64` platform architecture to the VS 2022 extension by updating the `Microsoft.VSSDK.BuildTools` package to the latest version (17.11.414) and adding a new entry for the `arm64` `ProductArchitecture`.

Built and tested on my Surface Pro 11 running VS 17.10.4 for ARM 64-bit. As best I can tell, everything seems to work.

I believe this PR addresses https://github.com/FortuneN/FineCodeCoverage/issues/436.

It's worth mentioning that the number of warnings produced during the build (at least from my local build) went from 2 to 19. The new warnings are likely due to updated analyzers from the package upgrade. Here are the new warnings:

The new warnings include:
* 13 of "warning VSTHRD110: Observe the awaitable result of this method call by awaiting it, assigning to a variable, or passing it to another method (https://github.com/Microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD110.md)"
* 3 of "warning VSSDK007: Await/join tasks created from ThreadHelper.JoinableTaskFactory.RunAsync (https://github.com/Microsoft/VSSDK-Analyzers/blob/main/doc/VSSDK007.md)"
* 1 of "warning VSIXCompatibility1001: The extension is incompatible with the targeted version of Visual Studio. More info at https://aka.ms/ExtensionSdkErrors."
  * This one is a bit more concerning as it seems to indicate an issue with other dependencies, but I've not determined how to resolve it. There a similar post on [SO](https://stackoverflow.com/questions/72076171/how-to-fix-the-extension-is-incompatible-with-the-targeted-version-of-visual-st), but I'm not seeing similarities with this code base.
    ```shell
      D:\.packages\nuget\microsoft.vssdk.compatibilityanalyzer\17.11.414\build\Microsoft.VsSDK.CompatibilityAnalyzer.targets(36,5): warning VSIXCompati
    bility1001: The extension is incompatible with the targeted version of Visual Studio. More info at https://aka.ms/ExtensionSdkErrors.  [D:\forks\Fi
    neCodeCoverage\FineCodeCoverage2022\FineCodeCoverage2022.csproj]
    D:\.packages\nuget\microsoft.vssdk.compatibilityanalyzer\17.11.414\build\Microsoft.VsSDK.CompatibilityAnalyzer.targets(36,5): warning VSIXCompatibi
    lity1001: Following references are incompatible. [D:\forks\FineCodeCoverage\FineCodeCoverage2022\FineCodeCoverage2022.csproj]
    D:\.packages\nuget\microsoft.vssdk.compatibilityanalyzer\17.11.414\build\Microsoft.VsSDK.CompatibilityAnalyzer.targets(36,5): warning VSIXCompatibi
    lity1001: Microsoft.VisualStudio.TestWindow.Interfaces.dll -> Microsoft.VisualStudio.Shell.Interop [D:\forks\FineCodeCoverage\FineCodeCoverage2022\
    FineCodeCoverage2022.csproj]
    ```