### PR TITLE
fix issue #444 From https://learn.microsoft.com/en-us/visualstudio/in…

### DIFF
--- a/FineCodeCoverage/source.extension.vsixmanifest
+++ b/FineCodeCoverage/source.extension.vsixmanifest
@@ -21,6 +21,6 @@
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
     </Assets>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.11,17.0)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,17.0)" DisplayName="Visual Studio core editor" />
     </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
…stall/workload-component-id-vs-professional?view=vs-2019 the version does not follow the sdk.