### PR TITLE
Check output type for exe for Azure function projects that do not pro…

### DIFF
--- a/FineCodeCoverage/FineCodeCoverage.csproj
+++ b/FineCodeCoverage/FineCodeCoverage.csproj
@@ -147,9 +147,6 @@
     <PackageReference Include="ExCSS">
       <Version>4.1.1</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.Build.Locator">
-      <Version>1.4.1</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Common">
       <Version>3.11.0</Version>
     </PackageReference>
@@ -181,6 +178,9 @@
       <Version>17.9.28</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.VCProjectEngine">
+      <Version>16.10.31320.204</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.8.3038">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/FineCodeCoverage2022/FineCodeCoverage2022.csproj
+++ b/FineCodeCoverage2022/FineCodeCoverage2022.csproj
@@ -146,9 +146,6 @@
     <PackageReference Include="ExCSS">
       <Version>4.1.1</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.Build.Locator">
-      <Version>1.4.1</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Common">
       <Version>4.10.0</Version>
     </PackageReference>
@@ -180,6 +177,9 @@
       <Version>17.10.48</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.VCProjectEngine">
+      <Version>17.10.40170</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.11.414">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/FineCodeCoverageTests/CoverageProject_Tests.cs
+++ b/FineCodeCoverageTests/CoverageProject_Tests.cs
@@ -12,7 +12,7 @@ namespace FineCodeCoverageTests
         [SetUp]
         public void SetUp()
         {
-            coverageProject = new CoverageProject(null, null, null, null, null, false);
+            coverageProject = new CoverageProject(null, null, null, null);
             tempProjectFilePath = Path.Combine(Path.GetTempPath(), "testproject.csproj");
             coverageProject.ProjectFile = tempProjectFilePath;
         }

--- a/FineCodeCoverageTests/CoverletConsole_Tests.cs
+++ b/FineCodeCoverageTests/CoverletConsole_Tests.cs
@@ -8,7 +8,6 @@ using AutoMoq;
 using FineCodeCoverage.Core.Utilities;
 using FineCodeCoverage.Engine.Coverlet;
 using FineCodeCoverage.Engine.Model;
-using FineCodeCoverage.Engine.OpenCover;
 using FineCodeCoverage.Options;
 using Moq;
 using NUnit.Framework;
@@ -46,8 +45,8 @@ namespace Test
         private Mock<ICoverageProject> SafeMockCoverageProject()
         {
             var mockCoverageProject = new Mock<ICoverageProject>();
-            mockCoverageProject.SetupGet(coverageProject => coverageProject.IncludedReferencedProjects).Returns(new List<string>());
-            mockCoverageProject.SetupGet(coverageProject => coverageProject.ExcludedReferencedProjects).Returns(new List<string>());
+            mockCoverageProject.SetupGet(coverageProject => coverageProject.IncludedReferencedProjects).Returns(new List<IReferencedProject>());
+            mockCoverageProject.SetupGet(coverageProject => coverageProject.ExcludedReferencedProjects).Returns(new List<IReferencedProject>());
             mockCoverageProject.SetupGet(coverageProject => coverageProject.Settings).Returns(new Mock<IAppOptions>().Object);
             return mockCoverageProject;
         }

--- a/FineCodeCoverageTests/CoverletDataCollectorUtil_RunAsync_Tests.cs
+++ b/FineCodeCoverageTests/CoverletDataCollectorUtil_RunAsync_Tests.cs
@@ -36,8 +36,8 @@ namespace Test
             mockCoverageProject = new Mock<ICoverageProject>();
             mockCoverageProject.Setup(cp => cp.Settings).Returns(new Mock<IAppOptions>().Object);
             mockCoverageProject.Setup(cp => cp.CoverageOutputFolder).Returns("");
-            mockCoverageProject.Setup(cp => cp.ExcludedReferencedProjects).Returns(new List<string>());
-            mockCoverageProject.Setup(cp => cp.IncludedReferencedProjects).Returns(new List<string>());
+            mockCoverageProject.Setup(cp => cp.ExcludedReferencedProjects).Returns(new List<IReferencedProject>());
+            mockCoverageProject.Setup(cp => cp.IncludedReferencedProjects).Returns(new List<IReferencedProject>());
             mockRunSettingsCoverletConfiguration = new Mock<IRunSettingsCoverletConfiguration>();
             coverletDataCollectorUtil.runSettingsCoverletConfiguration = mockRunSettingsCoverletConfiguration.Object;
             coverletDataCollectorUtil.coverageProject = mockCoverageProject.Object;
@@ -76,7 +76,7 @@ namespace Test
             var projectExclude = new string[] { "excluded" };
             mockCoverageProject.Setup(cp => cp.Settings.Exclude).Returns(projectExclude);
             mockCoverageProject.Setup(cp => cp.CoverageOutputFolder).Returns("");
-            var referencedExcluded = new List<string> { "referencedExcluded" };
+            var referencedExcluded = new List<IReferencedProject> { new ReferencedProject("","referencedExcluded",true) };
             mockCoverageProject.Setup(cp => cp.ExcludedReferencedProjects).Returns(referencedExcluded);
             mockRunSettingsCoverletConfiguration.Setup(rsc => rsc.Exclude).Returns("rsexclude");
             await coverletDataCollectorUtil.RunAsync(CancellationToken.None);
@@ -86,7 +86,7 @@ namespace Test
         [Test]
         public async Task Should_Not_Throw_When_Project_Setttings_Exclude_Is_Null_Async()
         {
-            var referencedExcluded = new List<string> { "referencedExcluded" };
+            var referencedExcluded = new List<IReferencedProject> { new ReferencedProject("", "referencedExcluded", true) };
             mockCoverageProject.Setup(cp => cp.ExcludedReferencedProjects).Returns(referencedExcluded);
             mockCoverageProject.Setup(cp => cp.CoverageOutputFolder).Returns("");
             mockRunSettingsCoverletConfiguration.Setup(rsc => rsc.Exclude).Returns("rsexclude");

--- a/FineCodeCoverageTests/MsCodeCoverage/MsCodeCoverageRunSettingsService_IsCollecting_Tests.cs
+++ b/FineCodeCoverageTests/MsCodeCoverage/MsCodeCoverageRunSettingsService_IsCollecting_Tests.cs
@@ -215,8 +215,8 @@ namespace FineCodeCoverageTests.MsCodeCoverage
             SetupAppOptionsProvider(RunMsCodeCoverage.IfInRunSettings);
 
             var projectSettings = new Mock<IAppOptions>().Object;
-            var excludedReferencedProjects = new List<string>();
-            var includedReferencedProjects = new List<string>();
+            var excludedReferencedProjects = new List<IReferencedProject>();
+            var includedReferencedProjects = new List<IReferencedProject>();
             var coverageProjects = new List<ICoverageProject>
             {
                 CreateCoverageProject(null),
@@ -531,8 +531,8 @@ namespace FineCodeCoverageTests.MsCodeCoverage
             IAppOptions settings = null,
             string coverageOutputFolder = "",
             string testDllFile = "", 
-            List<string> excludedReferencedProjects = null,
-            List<string> includedReferencedProjects = null,
+            List<IReferencedProject> excludedReferencedProjects = null,
+            List<IReferencedProject> includedReferencedProjects = null,
             string projectFile = ""
         )
         {

--- a/FineCodeCoverageTests/MsCodeCoverage/RunSettingsTemplateReplacementsFactory_Tests.cs
+++ b/FineCodeCoverageTests/MsCodeCoverage/RunSettingsTemplateReplacementsFactory_Tests.cs
@@ -61,8 +61,8 @@ namespace FineCodeCoverageTests.MsCodeCoverage
 
         private class TestUserRunSettingsProjectDetails : IUserRunSettingsProjectDetails
         {
-            public List<string> ExcludedReferencedProjects { get; set; }
-            public List<string> IncludedReferencedProjects { get; set; }
+            public List<IReferencedProject> ExcludedReferencedProjects { get; set; }
+            public List<IReferencedProject> IncludedReferencedProjects { get; set; }
             public string CoverageOutputFolder { get; set; }
             public IMsCodeCoverageOptions Settings { get; set; }
             public string TestDllFile { get; set; }
@@ -91,8 +91,8 @@ namespace FineCodeCoverageTests.MsCodeCoverage
                         CoverageOutputFolder = "",
                         TestDllFile = "",
                         Settings = new TestMsCodeCoverageOptions{ IncludeTestAssembly = true},
-                        ExcludedReferencedProjects = new List<string>(),
-                        IncludedReferencedProjects = new List<string>(),
+                        ExcludedReferencedProjects = new List<IReferencedProject>(),
+                        IncludedReferencedProjects = new List<IReferencedProject>(),
                     }
                 },
             };
@@ -119,8 +119,8 @@ namespace FineCodeCoverageTests.MsCodeCoverage
                         CoverageOutputFolder = outputFolder1,
                         TestDllFile = "",
                         Settings = new TestMsCodeCoverageOptions{ IncludeTestAssembly = true},
-                        ExcludedReferencedProjects = new List<string>(),
-                        IncludedReferencedProjects = new List<string>(),
+                        ExcludedReferencedProjects = new List<IReferencedProject>(),
+                        IncludedReferencedProjects = new List<IReferencedProject>(),
                     }
                 },
                 {
@@ -130,8 +130,8 @@ namespace FineCodeCoverageTests.MsCodeCoverage
                         CoverageOutputFolder = outputFolder2,
                         TestDllFile = "",
                         Settings = new TestMsCodeCoverageOptions{ IncludeTestAssembly = true},
-                        ExcludedReferencedProjects = new List<string>(),
-                        IncludedReferencedProjects = new List<string>(),
+                        ExcludedReferencedProjects = new List<IReferencedProject>(),
+                        IncludedReferencedProjects = new List<IReferencedProject>(),
                     }
                 },
                 {
@@ -182,8 +182,8 @@ namespace FineCodeCoverageTests.MsCodeCoverage
                         CoverageOutputFolder = "",
                         TestDllFile = "",
                         Settings = CreateSettings("1"),
-                        ExcludedReferencedProjects = new List<string>(),
-                        IncludedReferencedProjects = new List<string>(),
+                        ExcludedReferencedProjects = new List<IReferencedProject>(),
+                        IncludedReferencedProjects = new List<IReferencedProject>(),
                     }
                 },
                 {
@@ -193,8 +193,8 @@ namespace FineCodeCoverageTests.MsCodeCoverage
                         CoverageOutputFolder = "",
                         TestDllFile = "",
                         Settings = CreateSettings("2"),
-                        ExcludedReferencedProjects = new List<string>(),
-                        IncludedReferencedProjects = new List<string>(),
+                        ExcludedReferencedProjects = new List<IReferencedProject>(),
+                        IncludedReferencedProjects = new List<IReferencedProject>(),
                     }
                 },
                 {
@@ -247,8 +247,8 @@ namespace FineCodeCoverageTests.MsCodeCoverage
                             IncludeTestAssembly = includeTestAssembly1,
                             ModulePathsExclude = new string[]{ "ModulePathExclude"}
                         },
-                        ExcludedReferencedProjects = new List<string>(),
-                        IncludedReferencedProjects = new List<string>(),
+                        ExcludedReferencedProjects = new List<IReferencedProject>(),
+                        IncludedReferencedProjects = new List<IReferencedProject>(),
                         TestDllFile = @"Some\Path1"
                     }
                 },
@@ -258,8 +258,8 @@ namespace FineCodeCoverageTests.MsCodeCoverage
                     {
                         CoverageOutputFolder = "",
                         Settings = new TestMsCodeCoverageOptions{ IncludeTestAssembly = includeTestAssembly2},
-                        ExcludedReferencedProjects = new List<string>(),
-                        IncludedReferencedProjects = new List<string>(),
+                        ExcludedReferencedProjects = new List<IReferencedProject>(),
+                        IncludedReferencedProjects = new List<IReferencedProject>(),
                         TestDllFile = @"Some\Path2"
                     }
                 },
@@ -304,8 +304,8 @@ namespace FineCodeCoverageTests.MsCodeCoverage
                     ModulePathsExclude = new string[] { "ModulePathExclude" },
                     ModulePathsInclude = new string[] { "ModulePathInclude" }
                 },
-                ExcludedReferencedProjects = new List<string> { "ExcludedReferenced1" },
-                IncludedReferencedProjects = new List<string> { "IncludedReferenced1" },
+                ExcludedReferencedProjects = new List<IReferencedProject> { new ReferencedProject("", "ExcludedReferenced1", true) },
+                IncludedReferencedProjects = new List <IReferencedProject> { new ReferencedProject("", "IncludedReferenced1", true) },
             }
                 },
                 {
@@ -315,18 +315,18 @@ namespace FineCodeCoverageTests.MsCodeCoverage
                         CoverageOutputFolder = "",
                         TestDllFile = "",
                         Settings = new TestMsCodeCoverageOptions { IncludeTestAssembly = !included },
-                        ExcludedReferencedProjects = new List<string> { "ExcludedReferenced2" },
-                        IncludedReferencedProjects = new List<string> { "IncludedReferenced2" },
+                        ExcludedReferencedProjects = new List<IReferencedProject> { new ReferencedProject("", "ExcludedReferenced2", true) },
+                        IncludedReferencedProjects = new List<IReferencedProject> { new ReferencedProject("", "IncludedReferenced2", true) },
                     }
                 },
             };
 
             var projectDetails = userRunSettingsProjectDetailsLookup.Select(kvp => kvp.Value).ToList();
-            IEnumerable<string> allReferencedProjects = projectDetails.SelectMany(pd => included ? pd.IncludedReferencedProjects : pd.ExcludedReferencedProjects);
+            IEnumerable<IReferencedProject> allReferencedProjects = projectDetails.SelectMany(pd => included ? pd.IncludedReferencedProjects : pd.ExcludedReferencedProjects);
 
-            string GetExpectedExcludedOrIncludedEscaped(IEnumerable<string> excludedOrIncludedReferenced)
+            string GetExpectedExcludedOrIncludedEscaped(IEnumerable<IReferencedProject> excludedOrIncludedReferenced)
             {
-                return string.Join("", excludedOrIncludedReferenced.Select(referenced => ModulePathElement(MsCodeCoverageRegex.RegexModuleName(referenced))));
+                return string.Join("", excludedOrIncludedReferenced.Select(referenced => ModulePathElement(MsCodeCoverageRegex.RegexModuleName(referenced.AssemblyName,true))));
             }
             var expectedExcludes = GetExpectedExcludedOrIncludedEscaped(allReferencedProjects) + ModulePathElement(included ? "ModulePathInclude" : "ModulePathExclude");
 
@@ -352,8 +352,8 @@ namespace FineCodeCoverageTests.MsCodeCoverage
                         CoverageOutputFolder = "",
                         TestDllFile = "",
                         Settings = new TestMsCodeCoverageOptions{ IncludeTestAssembly = true},
-                        ExcludedReferencedProjects = new List<string>(),
-                        IncludedReferencedProjects = new List<string>(),
+                        ExcludedReferencedProjects = new List<IReferencedProject>(),
+                        IncludedReferencedProjects = new List<IReferencedProject>(),
                     }
                 },
                 {
@@ -363,8 +363,8 @@ namespace FineCodeCoverageTests.MsCodeCoverage
                         CoverageOutputFolder = "",
                         TestDllFile = "",
                         Settings = new TestMsCodeCoverageOptions{ IncludeTestAssembly = true},
-                        ExcludedReferencedProjects = new List<string>(),
-                        IncludedReferencedProjects = new List<string>(),
+                        ExcludedReferencedProjects = new List<IReferencedProject>(),
+                        IncludedReferencedProjects = new List<IReferencedProject>(),
                     }
                 }
             };
@@ -394,8 +394,8 @@ namespace FineCodeCoverageTests.MsCodeCoverage
                         CoverageOutputFolder = "",
                         TestDllFile = "",
                         Settings = new TestMsCodeCoverageOptions{ Enabled = project1Enabled, IncludeTestAssembly = true},
-                        ExcludedReferencedProjects = new List<string>(),
-                        IncludedReferencedProjects = new List<string>(),
+                        ExcludedReferencedProjects = new List<IReferencedProject>(),
+                        IncludedReferencedProjects = new List<IReferencedProject>(),
                     }
                 },
                 {
@@ -405,8 +405,8 @@ namespace FineCodeCoverageTests.MsCodeCoverage
                         CoverageOutputFolder = "",
                         TestDllFile = "",
                         Settings = new TestMsCodeCoverageOptions{ Enabled = project2Enabled,  IncludeTestAssembly = true},
-                        ExcludedReferencedProjects = new List<string>(),
-                        IncludedReferencedProjects = new List<string>(),
+                        ExcludedReferencedProjects = new List<IReferencedProject>(),
+                        IncludedReferencedProjects = new List<IReferencedProject>(),
                     }
                 }
             };
@@ -451,8 +451,8 @@ namespace FineCodeCoverageTests.MsCodeCoverage
             var mockSettings = new Mock<IAppOptions>();
             mockSettings.Setup(settings => settings.IncludeTestAssembly).Returns(includeTestAssembly);
             var mockCoverageProject = new Mock<ICoverageProject>();
-            mockCoverageProject.Setup(cp => cp.ExcludedReferencedProjects).Returns(new List<string>());
-            mockCoverageProject.Setup(cp => cp.IncludedReferencedProjects).Returns(new List<string>());
+            mockCoverageProject.Setup(cp => cp.ExcludedReferencedProjects).Returns(new List<IReferencedProject>());
+            mockCoverageProject.Setup(cp => cp.IncludedReferencedProjects).Returns(new List<IReferencedProject>());
             mockCoverageProject.Setup(cp => cp.TestDllFile).Returns("");
             mockCoverageProject.Setup(cp  => cp.Settings).Returns(mockSettings.Object);
             furtherSetup?.Invoke(mockCoverageProject);
@@ -587,15 +587,15 @@ namespace FineCodeCoverageTests.MsCodeCoverage
             var coverageProject = CreateCoverageProject(mock =>
             {
                 mock.Setup(cp => cp.Settings).Returns(msCodeCoverageOptions);
-                mock.Setup(cp => cp.ExcludedReferencedProjects).Returns(new List<string>
+                mock.Setup(cp => cp.ExcludedReferencedProjects).Returns(new List<IReferencedProject>
                 {
-                    "ModuleName"
+                    new ReferencedProject("","ModuleName",true)
                 });
                 mock.Setup(cp => cp.TestDllFile).Returns(@"Path\To\Test.dll");
             });
 
             var replacements = runSettingsTemplateReplacementsFactory.Create(coverageProject, null);
-            var expectedModulePathsExclude = $"{ModulePathElement(MsCodeCoverageRegex.RegexModuleName("ModuleName"))}{ModulePathElement(MsCodeCoverageRegex.RegexEscapePath(@"Path\To\Test.dll"))}{ModulePathElement("FromSettings")}";
+            var expectedModulePathsExclude = $"{ModulePathElement(MsCodeCoverageRegex.RegexModuleName("ModuleName", true))}{ModulePathElement(MsCodeCoverageRegex.RegexEscapePath(@"Path\To\Test.dll"))}{ModulePathElement("FromSettings")}";
             Assert.AreEqual(expectedModulePathsExclude, replacements.ModulePathsExclude);
         }
 
@@ -611,15 +611,15 @@ namespace FineCodeCoverageTests.MsCodeCoverage
             var coverageProject = CreateCoverageProject(mock =>
             {
                 mock.Setup(cp => cp.Settings).Returns(msCodeCoverageOptions);
-                mock.Setup(cp => cp.IncludedReferencedProjects).Returns(new List<string>
+                mock.Setup(cp => cp.IncludedReferencedProjects).Returns(new List<IReferencedProject>
                 {
-                    "ModuleName"
+                    new ReferencedProject("", "ModuleName", true)
                 });
                 mock.Setup(cp => cp.TestDllFile).Returns(@"Path\To\Test.dll");
             });
 
             var replacements = runSettingsTemplateReplacementsFactory.Create(coverageProject, null);
-            var expectedModulePathsInclude = $"{ModulePathElement(MsCodeCoverageRegex.RegexModuleName("ModuleName"))}{ModulePathElement(MsCodeCoverageRegex.RegexEscapePath(@"Path\To\Test.dll"))}{ModulePathElement("FromSettings")}";
+            var expectedModulePathsInclude = $"{ModulePathElement(MsCodeCoverageRegex.RegexModuleName("ModuleName",true))}{ModulePathElement(MsCodeCoverageRegex.RegexEscapePath(@"Path\To\Test.dll"))}{ModulePathElement("FromSettings")}";
             Assert.AreEqual(expectedModulePathsInclude, replacements.ModulePathsInclude);
         }
 

--- a/FineCodeCoverageTests/OpenCoverExeArgumentsProvider_Tests.cs
+++ b/FineCodeCoverageTests/OpenCoverExeArgumentsProvider_Tests.cs
@@ -222,7 +222,7 @@ namespace FineCodeCoverageTests
             var openCoverExeArgumentsProvider = new OpenCoverExeArgumentsProvider();
             var mockCoverageProject = SafeMockCoverageProject();
             mockCoverageProject.Setup(coverageProject => coverageProject.IncludedReferencedProjects)
-                .Returns(new List<string> { "Referenced1", "Referenced2" });
+                .Returns(new List<IReferencedProject> { new ReferencedProject("", "Referenced1", true), new ReferencedProject("", "Referenced2", true) });
             
             var arguments = openCoverExeArgumentsProvider.Provide(mockCoverageProject.Object, "");
             
@@ -241,7 +241,7 @@ namespace FineCodeCoverageTests
             var openCoverExeArgumentsProvider = new OpenCoverExeArgumentsProvider();
             var mockCoverageProject = SafeMockCoverageProject();
             mockCoverageProject.Setup(coverageProject => coverageProject.ExcludedReferencedProjects)
-                .Returns(new List<string> { "Referenced1", "Referenced2" });
+                .Returns(new List<IReferencedProject> { new ReferencedProject("", "Referenced1", true), new ReferencedProject("", "Referenced2", true) });
 
             var arguments = openCoverExeArgumentsProvider.Provide(mockCoverageProject.Object, "");
 
@@ -264,8 +264,8 @@ namespace FineCodeCoverageTests
         private Mock<ICoverageProject> SafeMockCoverageProject()
         {
             var mockCoverageProject = new Mock<ICoverageProject>();
-            mockCoverageProject.SetupGet(coverageProject => coverageProject.IncludedReferencedProjects).Returns(new List<string>());
-            mockCoverageProject.SetupGet(coverageProject => coverageProject.ExcludedReferencedProjects).Returns(new List<string>());
+            mockCoverageProject.SetupGet(coverageProject => coverageProject.IncludedReferencedProjects).Returns(new List<IReferencedProject>());
+            mockCoverageProject.SetupGet(coverageProject => coverageProject.ExcludedReferencedProjects).Returns(new List<IReferencedProject>());
             mockCoverageProject.SetupGet(coverageProject => coverageProject.Settings).Returns(new Mock<IAppOptions>().Object);
             return mockCoverageProject;
         }

--- a/FineCodeCoverageTests/ReferencedProject_Tests.cs
+++ b/FineCodeCoverageTests/ReferencedProject_Tests.cs
@@ -1,5 +1,5 @@
 using System.IO;
-using FineCodeCoverage.Core.Model;
+using FineCodeCoverage.Engine.Model;
 using NUnit.Framework;
 
 namespace Test
@@ -24,7 +24,7 @@ namespace Test
         {
             var property = addProperty ? $"<{ReferencedProject.excludeFromCodeCoveragePropertyName}/>" : "";
             WriteProperty(property);
-            var referencedProject = new ReferencedProject(tempProjectFilePath, "");
+            var referencedProject = new ReferencedProject(tempProjectFilePath, "",true);
             Assert.AreEqual(addProperty, referencedProject.ExcludeFromCodeCoverage);
 
         }

--- a/SharedProject/Core/Coverlet/Console/CoverletConsoleUtil.cs
+++ b/SharedProject/Core/Coverlet/Console/CoverletConsoleUtil.cs
@@ -37,7 +37,7 @@ namespace FineCodeCoverage.Engine.Coverlet
                 coverletSettings.Add($@"--exclude ""{value.Replace("\"", "\\\"").Trim(' ', '\'')}""");
             }
 
-            foreach (var referencedProjectExcludedFromCodeCoverage in project.ExcludedReferencedProjects)
+            foreach (var referencedProjectExcludedFromCodeCoverage in project.ExcludedReferencedProjects.Select(rp => rp.AssemblyName))
             {
                 coverletSettings.Add($@"--exclude ""[{referencedProjectExcludedFromCodeCoverage}]*""");
             }
@@ -47,7 +47,7 @@ namespace FineCodeCoverage.Engine.Coverlet
                 coverletSettings.Add($@"--include ""{value.Replace("\"", "\\\"").Trim(' ', '\'')}""");
             }
 
-            foreach (var includedReferencedProject in project.IncludedReferencedProjects)
+            foreach (var includedReferencedProject in project.IncludedReferencedProjects.Select(rp => rp.AssemblyName))
             {
                 coverletSettings.Add($@"--include ""[{includedReferencedProject}]*""");
             }

--- a/SharedProject/Core/Coverlet/DataCollector/CoverletDataCollectorUtil.cs
+++ b/SharedProject/Core/Coverlet/DataCollector/CoverletDataCollectorUtil.cs
@@ -172,7 +172,7 @@ namespace FineCodeCoverage.Engine.Coverlet
             dataCollectorSettingsBuilder
                 .WithResultsDirectory(coverageProject.CoverageOutputFolder);
 
-            string[] projectExcludes = coverageProject.ExcludedReferencedProjects.Select(erp => $"[{erp}]*").ToArray();
+            string[] projectExcludes = coverageProject.ExcludedReferencedProjects.Select(erp => $"[{erp.AssemblyName}]*").ToArray();
             if(coverageProject.Settings.Exclude != null)
             {
                 projectExcludes = projectExcludes.Concat(SanitizeExcludesOrIncludes(coverageProject.Settings.Exclude)).ToArray();
@@ -190,7 +190,7 @@ namespace FineCodeCoverage.Engine.Coverlet
                     SanitizeExcludesOrIncludes(coverageProject.Settings.ExcludeByAttribute), 
                     runSettingsCoverletConfiguration.ExcludeByAttribute);
 
-            string[] projectIncludes = coverageProject.IncludedReferencedProjects.Select(irp => $"[{irp}]*").ToArray();
+            string[] projectIncludes = coverageProject.IncludedReferencedProjects.Select(irp => $"[{irp.AssemblyName}]*").ToArray();
             if(coverageProject.Settings.Include != null)
             {
                 projectIncludes = projectIncludes.Concat(SanitizeExcludesOrIncludes(coverageProject.Settings.Include)).ToArray();

--- a/SharedProject/Core/Initialization/Initializer.cs
+++ b/SharedProject/Core/Initialization/Initializer.cs
@@ -3,7 +3,6 @@ using System.ComponentModel.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 using FineCodeCoverage.Engine;
-using FineCodeCoverage.Engine.Model;
 
 namespace FineCodeCoverage.Core.Initialization
 {
@@ -15,7 +14,6 @@ namespace FineCodeCoverage.Core.Initialization
     {
         private readonly IFCCEngine fccEngine;
         private readonly ILogger logger;
-        private readonly ICoverageProjectFactory coverageProjectFactory;
         private readonly IFirstTimeToolWindowOpener firstTimeToolWindowOpener;
 
         public InitializeStatus InitializeStatus { get; set; } = InitializeStatus.Initializing;
@@ -25,7 +23,6 @@ namespace FineCodeCoverage.Core.Initialization
         public Initializer(
             IFCCEngine fccEngine, 
             ILogger logger, 
-            ICoverageProjectFactory coverageProjectFactory,
             IFirstTimeToolWindowOpener firstTimeToolWindowOpener,
             [ImportMany]
             IInitializable[] initializables
@@ -33,7 +30,6 @@ namespace FineCodeCoverage.Core.Initialization
         {
             this.fccEngine = fccEngine;
             this.logger = logger;
-            this.coverageProjectFactory = coverageProjectFactory;
             this.firstTimeToolWindowOpener = firstTimeToolWindowOpener;
         }
         public async Task InitializeAsync(CancellationToken cancellationToken)
@@ -44,7 +40,6 @@ namespace FineCodeCoverage.Core.Initialization
                 logger.Log($"Initializing");
 
                 cancellationToken.ThrowIfCancellationRequested();
-                coverageProjectFactory.Initialize();
 
                 fccEngine.Initialize(cancellationToken);
 

--- a/SharedProject/Core/Model/CoverageProjectFactory.cs
+++ b/SharedProject/Core/Model/CoverageProjectFactory.cs
@@ -1,13 +1,6 @@
-﻿using System;
-using System.ComponentModel.Composition;
-using System.Threading.Tasks;
-using EnvDTE;
-using EnvDTE80;
+﻿using System.ComponentModel.Composition;
 using FineCodeCoverage.Engine.FileSynchronization;
 using FineCodeCoverage.Options;
-using Microsoft.Build.Locator;
-using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Threading;
 
 namespace FineCodeCoverage.Engine.Model
 {
@@ -16,54 +9,30 @@ namespace FineCodeCoverage.Engine.Model
     {
         private readonly IAppOptionsProvider appOptionsProvider;
         private readonly IFileSynchronizationUtil fileSynchronizationUtil;
-        private readonly ILogger logger;
         private readonly ICoverageProjectSettingsManager coverageProjectSettingsManager;
-        private bool canUseMsBuildWorkspace = true;
-        private readonly AsyncLazy<DTE2> lazyDTE2;
+        private readonly IReferencedProjectsHelper referencedProjectsHelper;
 
         [ImportingConstructor]
 		public CoverageProjectFactory(
 			IAppOptionsProvider appOptionsProvider,
 			IFileSynchronizationUtil fileSynchronizationUtil, 
-			ILogger logger,
             ICoverageProjectSettingsManager coverageProjectSettingsManager,
-            [Import(typeof(SVsServiceProvider))]
-			IServiceProvider serviceProvider)
+            IReferencedProjectsHelper referencedProjectsHelper
+            )
         {
             this.appOptionsProvider = appOptionsProvider;
             this.fileSynchronizationUtil = fileSynchronizationUtil;
-            this.logger = logger;
             this.coverageProjectSettingsManager = coverageProjectSettingsManager;
-
-            lazyDTE2 = new AsyncLazy<DTE2>(async () =>
-            {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                return (DTE2)serviceProvider.GetService(typeof(DTE));
-            },ThreadHelper.JoinableTaskFactory);
+            this.referencedProjectsHelper = referencedProjectsHelper;
         }
 
-        public void Initialize()
+        public ICoverageProject Create()
         {
-            try
-            {
-                MSBuildLocator.RegisterDefaults();
-            }
-            catch
-            {
-                canUseMsBuildWorkspace = false;
-            }
-        }
-        public async Task<ICoverageProject> CreateAsync()
-        {
-            var dte2 = await lazyDTE2.GetValueAsync();
-
             return new CoverageProject(
                 appOptionsProvider,
                 fileSynchronizationUtil, 
-                logger, 
-                dte2, 
                 coverageProjectSettingsManager,
-                canUseMsBuildWorkspace);
+                referencedProjectsHelper);
         }
     }
 }

--- a/SharedProject/Core/Model/ICoverageProject.cs
+++ b/SharedProject/Core/Model/ICoverageProject.cs
@@ -12,8 +12,8 @@ namespace FineCodeCoverage.Engine.Model
         string CoverageOutputFile { get; }
         string CoverageOutputFolder { get; set; }
         string DefaultCoverageOutputFolder { get; }
-        List<string> ExcludedReferencedProjects { get; }
-        List<string> IncludedReferencedProjects { get; }
+        List<IReferencedProject> ExcludedReferencedProjects { get; }
+        List<IReferencedProject> IncludedReferencedProjects { get; }
         string FailureDescription { get; set; }
         string FailureStage { get; set; }
         bool HasFailed { get; }

--- a/SharedProject/Core/Model/ICoverageProjectFactory.cs
+++ b/SharedProject/Core/Model/ICoverageProjectFactory.cs
@@ -1,10 +1,7 @@
-﻿using System.Threading.Tasks;
-
-namespace FineCodeCoverage.Engine.Model
+﻿namespace FineCodeCoverage.Engine.Model
 {
     internal interface ICoverageProjectFactory
     {
-		Task<ICoverageProject> CreateAsync();
-        void Initialize();
+		ICoverageProject Create();
     }
 }

--- a/SharedProject/Core/Model/ReferencedProjects/CPPReferencedProjectsHelper.cs
+++ b/SharedProject/Core/Model/ReferencedProjects/CPPReferencedProjectsHelper.cs
@@ -1,0 +1,73 @@
+﻿using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.VCProjectEngine;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace FineCodeCoverage.Engine.Model
+{
+    [Export(typeof(ICPPReferencedProjectsHelper))]
+    internal class CPPReferencedProjectsHelper : ICPPReferencedProjectsHelper
+    {
+        private VCProject GetReferencedVCProject(VCProjectReference projectReference)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            return projectReference.ReferencedProject as VCProject
+                ?? (projectReference.ReferencedProject as EnvDTE.Project)?.Object as VCProject;
+        }
+
+        private bool? IsDll(VCProject vcProject)
+        {
+            if (!(vcProject.Configurations is IEnumerable configurations))
+                return null;
+
+            var configuration = configurations.Cast<VCConfiguration>().FirstOrDefault();
+            if (configuration == null)
+                return null;
+
+            bool isDll = configuration.ConfigurationType == ConfigurationTypes.typeDynamicLibrary;
+            bool isApplication = configuration.ConfigurationType == ConfigurationTypes.typeApplication;
+            if (!isDll && !isApplication)
+                return null;
+            return isDll;
+        }
+
+        private string GetCPPProjectReferenceProjectFilePath(VCProjectReference reference)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            var vsReference = reference.Reference as VSLangProj.Reference;
+            var sourceProject = vsReference.SourceProject;
+            return sourceProject.FileName;
+        }
+
+        public async Task<List<IExcludableReferencedProject>> GetInstrumentableReferencedProjectsAsync(VCProject cppProject)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            if (!(cppProject.VCReferences is IEnumerable vcReferences))
+                return null;
+
+            return vcReferences
+                .OfType<VCProjectReference>()
+                .Select(reference =>
+                {
+                    var referencedProject = GetReferencedVCProject(reference);
+
+                    var isDll = IsDll(referencedProject);
+                    return isDll.HasValue ?(IExcludableReferencedProject) new ReferencedProject(
+                            GetCPPProjectReferenceProjectFilePath(reference),
+                            Path.GetFileNameWithoutExtension(reference.FullPath),
+                            isDll.Value
+                        )
+                        : null;
+                })
+                .Where(p => p != null)
+                .ToList();
+        }
+
+    }
+
+}

--- a/SharedProject/Core/Model/ReferencedProjects/DotNetReferencedProjectsHelper.cs
+++ b/SharedProject/Core/Model/ReferencedProjects/DotNetReferencedProjectsHelper.cs
@@ -1,0 +1,52 @@
+﻿using EnvDTE;
+using Microsoft.VisualStudio.Shell;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Threading.Tasks;
+using VSLangProj;
+using VSLangProj80;
+
+namespace FineCodeCoverage.Engine.Model
+{
+    [Export(typeof(IDotNetReferencedProjectsHelper))]
+    internal class DotNetReferencedProjectsHelper : IDotNetReferencedProjectsHelper
+    {
+        public async Task<List<IExcludableReferencedProject>> GetReferencedProjectsAsync(VSProject vsProject)
+        {
+            var referencedProjects = (await System.Threading.Tasks.Task.WhenAll(GetReferencedSourceProjects(vsProject).Select(GetReferencedProjectAsync))).ToList();
+            return new List<IExcludableReferencedProject>(referencedProjects);
+        }
+
+        private IEnumerable<Project> GetReferencedSourceProjects(VSProject vsproject)
+        {
+            return vsproject.References.Cast<Reference>().Where(r => r.SourceProject != null)
+                .Select(r => r.SourceProject);
+        }
+
+        private async Task<ReferencedProject> GetReferencedProjectAsync(Project project)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            var (assemblyName, isDll) = await GetAssemblyNameIsDllAsync(project);
+            return new ReferencedProject(project.FullName, assemblyName, isDll);
+        }
+
+        private async Task<(string, bool)> GetAssemblyNameIsDllAsync(Project project)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            var assemblyNameProperty = project.Properties.Item(nameof(ProjectProperties3.AssemblyName));
+            var assemblyName = assemblyNameProperty?.Value.ToString() ?? project.Name;
+            var outputTypeProperty = project.Properties.Item(nameof(ProjectProperties3.OutputType));
+            var isDll = true;
+            if (outputTypeProperty != null)
+            {
+                prjOutputType po = (prjOutputType)Enum.Parse(typeof(prjOutputType), outputTypeProperty.Value.ToString());
+                isDll = po == prjOutputType.prjOutputTypeLibrary;
+            }
+
+            return (assemblyName, isDll);
+        }
+    }
+
+}

--- a/SharedProject/Core/Model/ReferencedProjects/ICPPReferencedProjectsHelper.cs
+++ b/SharedProject/Core/Model/ReferencedProjects/ICPPReferencedProjectsHelper.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.VisualStudio.VCProjectEngine;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace FineCodeCoverage.Engine.Model
+{
+    internal interface ICPPReferencedProjectsHelper
+    {
+        Task<List<IExcludableReferencedProject>> GetInstrumentableReferencedProjectsAsync(VCProject cppProject);
+    }
+
+}

--- a/SharedProject/Core/Model/ReferencedProjects/IDotNetReferencedProjectsHelper.cs
+++ b/SharedProject/Core/Model/ReferencedProjects/IDotNetReferencedProjectsHelper.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using VSLangProj;
+
+namespace FineCodeCoverage.Engine.Model
+{
+    internal interface IDotNetReferencedProjectsHelper
+    {
+        Task<List<IExcludableReferencedProject>> GetReferencedProjectsAsync(VSProject vsProject);
+    }
+}

--- a/SharedProject/Core/Model/ReferencedProjects/IExcludableReferencedProject.cs
+++ b/SharedProject/Core/Model/ReferencedProjects/IExcludableReferencedProject.cs
@@ -1,0 +1,7 @@
+﻿namespace FineCodeCoverage.Engine.Model
+{
+    interface IExcludableReferencedProject : IReferencedProject
+    {
+        bool ExcludeFromCodeCoverage { get; }
+    }
+}

--- a/SharedProject/Core/Model/ReferencedProjects/IProjectFileReferencedProjectsHelper.cs
+++ b/SharedProject/Core/Model/ReferencedProjects/IProjectFileReferencedProjectsHelper.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using System.Xml.Linq;
+
+namespace FineCodeCoverage.Engine.Model
+{
+    interface IProjectFileReferencedProjectsHelper
+    {
+        List<IExcludableReferencedProject> GetReferencedProjects(string projectFile, XElement projectFileXElement);
+    }
+}

--- a/SharedProject/Core/Model/ReferencedProjects/IReferencedProject.cs
+++ b/SharedProject/Core/Model/ReferencedProjects/IReferencedProject.cs
@@ -1,0 +1,8 @@
+﻿namespace FineCodeCoverage.Engine.Model
+{
+    internal interface IReferencedProject
+    {
+        string AssemblyName { get; }
+        bool IsDll { get; }
+    }
+}

--- a/SharedProject/Core/Model/ReferencedProjects/IReferencedProjectsHelper.cs
+++ b/SharedProject/Core/Model/ReferencedProjects/IReferencedProjectsHelper.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace FineCodeCoverage.Engine.Model
+{
+    internal interface IReferencedProjectsHelper
+    {
+
+        // todo - should not need ms build workspaces or parsing the project file
+        Task<List<IExcludableReferencedProject>> GetReferencedProjectsAsync(
+            string projectFile, Func<XElement> projectFileXElementProvider);
+    }
+}

--- a/SharedProject/Core/Model/ReferencedProjects/IVsApiReferencedProjectsHelper.cs
+++ b/SharedProject/Core/Model/ReferencedProjects/IVsApiReferencedProjectsHelper.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace FineCodeCoverage.Engine.Model
+{
+    internal interface IVsApiReferencedProjectsHelper
+    {
+        Task<List<IExcludableReferencedProject>> GetReferencedProjectsAsync(string projectFile);
+    }
+}

--- a/SharedProject/Core/Model/ReferencedProjects/ProjectFileReferencedProjectsHelper.cs
+++ b/SharedProject/Core/Model/ReferencedProjects/ProjectFileReferencedProjectsHelper.cs
@@ -1,0 +1,64 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using System.Xml.XPath;
+
+namespace FineCodeCoverage.Engine.Model
+{
+    // todo - remove this ? Should not be necessary
+    [Export(typeof(IProjectFileReferencedProjectsHelper))]
+    internal class ProjectFileReferencedProjectsHelper : IProjectFileReferencedProjectsHelper
+
+    {
+        private readonly ILogger logger;
+
+        [ImportingConstructor]
+        public ProjectFileReferencedProjectsHelper(ILogger logger)
+        {
+            this.logger = logger;
+        }
+
+        public List<IExcludableReferencedProject> GetReferencedProjects(
+            string projectFile, XElement projectFileXElement
+        )
+        {
+            /*
+			<ItemGroup>
+				<ProjectReference Include="..\BranchCoverage\Branch_Coverage.csproj" />
+				<ProjectReference Include="..\FxClassLibrary1\FxClassLibrary1.csproj"></ProjectReference>
+			</ItemGroup>
+			 */
+
+            var xprojectReferences = projectFileXElement.XPathSelectElements($"/ItemGroup/ProjectReference[@Include]");
+            var requiresDesignTimeBuild = false;
+            List<string> referencedProjectFiles = new List<string>();
+            foreach (var xprojectReference in xprojectReferences)
+            {
+                var referencedProjectProjectFile = xprojectReference.Attribute("Include").Value;
+                if (referencedProjectProjectFile.Contains("$("))
+                {
+                    logger.Log($"Cannot exclude referenced project {referencedProjectProjectFile} of {projectFile} with {ReferencedProject.excludeFromCodeCoveragePropertyName}.  Cannot use MSBuildWorkspace");
+                }
+                else
+                {
+                    if (!Path.IsPathRooted(referencedProjectProjectFile))
+                    {
+                        referencedProjectProjectFile = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(projectFile), referencedProjectProjectFile));
+                    }
+                    referencedProjectFiles.Add(referencedProjectProjectFile);
+                }
+
+            }
+
+            if (requiresDesignTimeBuild)
+            {
+                return new List<IExcludableReferencedProject>();
+
+            }
+
+            return referencedProjectFiles.Select(referencedProjectProjectFile => (IExcludableReferencedProject)new ReferencedProject(referencedProjectProjectFile)).ToList();
+        }
+    }
+}

--- a/SharedProject/Core/Model/ReferencedProjects/ReferencedProject.cs
+++ b/SharedProject/Core/Model/ReferencedProjects/ReferencedProject.cs
@@ -3,18 +3,21 @@ using System.Xml.Linq;
 using System.Xml.XPath;
 using FineCodeCoverage.Core.Utilities;
 
-namespace FineCodeCoverage.Core.Model
+namespace FineCodeCoverage.Engine.Model
 {
-    internal class ReferencedProject
-	{
+    internal class ReferencedProject : IExcludableReferencedProject
+    {
 		internal const string excludeFromCodeCoveragePropertyName = "FCCExcludeFromCodeCoverage";
         private readonly string projectPath;
+		
 
-        public ReferencedProject(string projectPath,string assemblyName)
+        public ReferencedProject(string projectPath,string assemblyName,bool isDll)
         {
-			AssemblyName = assemblyName;
             this.projectPath = projectPath;
+            AssemblyName = assemblyName;
+            IsDll = isDll;
         }
+
 		public ReferencedProject(string projectPath)
         {
 			this.projectPath = projectPath;
@@ -43,8 +46,17 @@ namespace FineCodeCoverage.Core.Model
 			return result;
 		}
 
-		public string AssemblyName { get; private set; }
-		public bool ExcludeFromCodeCoverage
+		public string AssemblyName { get; }
+
+		public bool IsDll { get; } = true;
+
+        /*
+			Annoyingly by allowing <FCCExcludeFromCodeCoverage /> and not <FCCExcludeFromCodeCoverage>true</FCCExcludeFromCodeCoverage>
+			it is not possible to use IVsBuildPropertyStorage.
+			Todo - consider breaking change to <FCCExcludeFromCodeCoverage>true</FCCExcludeFromCodeCoverage>
+			Given that purpose is for dotnet framework.....
+		*/
+        public bool ExcludeFromCodeCoverage
 		{
 			get
 			{

--- a/SharedProject/Core/Model/ReferencedProjects/ReferencedProjectsHelper.cs
+++ b/SharedProject/Core/Model/ReferencedProjects/ReferencedProjectsHelper.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace FineCodeCoverage.Engine.Model
+{
+    [Export(typeof(IReferencedProjectsHelper))]
+    internal class ReferencedProjectsHelper : IReferencedProjectsHelper
+    {
+        private readonly IVsApiReferencedProjectsHelper vsApiReferencedProjectsHelper;
+        private readonly IProjectFileReferencedProjectsHelper projectFileReferencedProjectsHelper;
+        private string projectFile { get; set; }
+        private Func<XElement> projectFileXElementProvider;
+
+        [ImportingConstructor]
+        public ReferencedProjectsHelper(
+            IVsApiReferencedProjectsHelper vsApiReferencedProjectsHelper,
+            IProjectFileReferencedProjectsHelper projectFileReferencedProjectsHelper
+        )
+        {
+            this.vsApiReferencedProjectsHelper = vsApiReferencedProjectsHelper;
+            this.projectFileReferencedProjectsHelper = projectFileReferencedProjectsHelper;
+        }
+
+        public async Task<List<IExcludableReferencedProject>> GetReferencedProjectsAsync(string projectFile, Func<XElement> projectFileXElementProvider)
+        {
+            this.projectFileXElementProvider = projectFileXElementProvider;
+            this.projectFile = projectFile;
+            var referencedProjects = await GetReferencedProjectsAsync();
+            return new List<IExcludableReferencedProject>(referencedProjects);
+        }
+
+        private async Task<List<IExcludableReferencedProject>> GetReferencedProjectsAsync()
+        {
+            return await SafeGetReferencedProjectsFromVSApiAsync() ?? projectFileReferencedProjectsHelper.GetReferencedProjects(projectFile, projectFileXElementProvider());
+        }
+
+        private async Task<List<IExcludableReferencedProject>> SafeGetReferencedProjectsFromVSApiAsync()
+        {
+            try
+            {
+                return await vsApiReferencedProjectsHelper.GetReferencedProjectsAsync(projectFile);
+            }
+            catch (Exception) { }
+            return null;
+        }
+    }
+
+}

--- a/SharedProject/Core/Model/ReferencedProjects/VsApiReferencedProjectsHelper.cs
+++ b/SharedProject/Core/Model/ReferencedProjects/VsApiReferencedProjectsHelper.cs
@@ -1,0 +1,84 @@
+﻿using EnvDTE;
+using EnvDTE80;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
+using Microsoft.VisualStudio.VCProjectEngine;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Threading.Tasks;
+using VSLangProj;
+
+namespace FineCodeCoverage.Engine.Model
+{
+
+    [Export(typeof(IVsApiReferencedProjectsHelper))]
+    internal class VsApiReferencedProjectsHelper : IVsApiReferencedProjectsHelper
+    {
+        private readonly ICPPReferencedProjectsHelper cppReferencedProjectsHelper;
+        private readonly IDotNetReferencedProjectsHelper dotNetReferencedProjectsHelper;
+        private AsyncLazy<DTE2> lazyDTE2;
+
+        [ImportingConstructor]
+        public VsApiReferencedProjectsHelper(
+            [Import(typeof(SVsServiceProvider))]
+            IServiceProvider serviceProvider,
+            ICPPReferencedProjectsHelper cppReferencedProjectsHelper,
+            IDotNetReferencedProjectsHelper dotNetReferencedProjectsHelper
+        )
+        {
+            lazyDTE2 = new AsyncLazy<DTE2>(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                return (DTE2)serviceProvider.GetService(typeof(DTE));
+            }, ThreadHelper.JoinableTaskFactory);
+            this.cppReferencedProjectsHelper = cppReferencedProjectsHelper;
+            this.dotNetReferencedProjectsHelper = dotNetReferencedProjectsHelper;
+        }
+        public async Task<List<IExcludableReferencedProject>> GetReferencedProjectsAsync(string projectFile)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            var project = await GetProjectAsync(projectFile);
+
+            if (project == null)
+            {
+                return null;
+            }
+
+            var cppProject = project.Object as VCProject;
+            if (cppProject != null)
+            {
+                return await cppReferencedProjectsHelper.GetInstrumentableReferencedProjectsAsync(cppProject);
+            }
+
+            var vsProject = project.Object as VSProject;
+            if (vsProject != null)
+            {
+                return await dotNetReferencedProjectsHelper.GetReferencedProjectsAsync(vsProject);
+            }
+
+            return null;
+        }
+
+        private async Task<Project> GetProjectAsync(string projectFile)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            var dte2 = await lazyDTE2.GetValueAsync();
+            // note that cannot do dte.Solution.Projects.Item(ProjectFile) - fails when dots in path
+            return dte2.Solution.Projects.Cast<Project>().FirstOrDefault(p =>
+            {
+                ThreadHelper.ThrowIfNotOnUIThread();
+                //have to try here as unloaded projects will throw
+                var projectFullName = "";
+                try
+                {
+                    projectFullName = p.FullName;
+                }
+                catch { }
+                return projectFullName == projectFile;
+            });
+        }
+    }
+
+}

--- a/SharedProject/Core/MsTestPlatform/CodeCoverage/IUserRunSettingsProjectDetails.cs
+++ b/SharedProject/Core/MsTestPlatform/CodeCoverage/IUserRunSettingsProjectDetails.cs
@@ -1,12 +1,13 @@
-﻿using FineCodeCoverage.Options;
+﻿using FineCodeCoverage.Engine.Model;
+using FineCodeCoverage.Options;
 using System.Collections.Generic;
 
 namespace FineCodeCoverage.Engine.MsTestPlatform.CodeCoverage
 {
     internal interface IUserRunSettingsProjectDetails
     {
-        List<string> ExcludedReferencedProjects { get; set; }
-        List<string> IncludedReferencedProjects { get; set; }
+        List<IReferencedProject> ExcludedReferencedProjects { get; set; }
+        List<IReferencedProject> IncludedReferencedProjects { get; set; }
         string CoverageOutputFolder { get; set; }
         IMsCodeCoverageOptions Settings { get; set; }
         string TestDllFile { get; set; }

--- a/SharedProject/Core/MsTestPlatform/CodeCoverage/MsCodeCoverageRegex.cs
+++ b/SharedProject/Core/MsTestPlatform/CodeCoverage/MsCodeCoverageRegex.cs
@@ -7,9 +7,15 @@
             return path.Replace(@"\", @"\\");
         }
 
-        public static string RegexModuleName(string moduleName)
+        public static string RegexModuleName(string moduleName, bool isDll)
+        {   
+            var extensionMatch = isDll ? "dll" : "(dll|exe)";
+            return $".*\\\\{EscapeDots(moduleName)}\\.{extensionMatch}$";
+        }
+
+        private static string EscapeDots(string moduleName)
         {
-            return $".*\\\\{moduleName}.dll$";
+            return moduleName.Replace(".", @"\.");
         }
     }
 

--- a/SharedProject/Core/MsTestPlatform/CodeCoverage/MsCodeCoverageRunSettingsService.cs
+++ b/SharedProject/Core/MsTestPlatform/CodeCoverage/MsCodeCoverageRunSettingsService.cs
@@ -29,8 +29,8 @@ namespace FineCodeCoverage.Engine.MsTestPlatform.CodeCoverage
             public IMsCodeCoverageOptions Settings { get; set; }
             public string CoverageOutputFolder { get; set; }
             public string TestDllFile { get; set; }
-            public List<string> ExcludedReferencedProjects { get; set; }
-            public List<string> IncludedReferencedProjects { get; set; }
+            public List<IReferencedProject> ExcludedReferencedProjects { get; set; }
+            public List<IReferencedProject> IncludedReferencedProjects { get; set; }
         }
         private class CoverageProjectsByType
         {

--- a/SharedProject/Core/MsTestPlatform/CodeCoverage/RunSettingsTemplateReplacementsFactory.cs
+++ b/SharedProject/Core/MsTestPlatform/CodeCoverage/RunSettingsTemplateReplacementsFactory.cs
@@ -1,5 +1,4 @@
-﻿using FineCodeCoverage.Core.Model;
-using FineCodeCoverage.Engine.Model;
+﻿using FineCodeCoverage.Engine.Model;
 using FineCodeCoverage.Options;
 using Microsoft.VisualStudio.TestWindow.Extensibility;
 using System;
@@ -160,14 +159,14 @@ namespace FineCodeCoverage.Engine.MsTestPlatform.CodeCoverage
         }
 
         private IEnumerable<string> GetAdditionalModulePaths(
-            IEnumerable<string> referencedProjects,
+            IEnumerable<IReferencedProject> referencedProjects,
             string testDllFile,
             bool includeTestAssembly,
             bool isInclude
             )
         {
             var additionalReferenced = referencedProjects.Select(
-                rp => MsCodeCoverageRegex.RegexModuleName(rp));
+                rp => MsCodeCoverageRegex.RegexModuleName(rp.AssemblyName,rp.IsDll));
             if(includeTestAssembly == isInclude)
             {
                 additionalReferenced = additionalReferenced.Append(MsCodeCoverageRegex.RegexEscapePath(testDllFile));

--- a/SharedProject/Core/MsTestPlatform/TestingPlatform/DisableTestingPlatformServerCapabilityGlobalPropertiesProvider.cs
+++ b/SharedProject/Core/MsTestPlatform/TestingPlatform/DisableTestingPlatformServerCapabilityGlobalPropertiesProvider.cs
@@ -55,7 +55,7 @@ namespace FineCodeCoverage.Core.MsTestPlatform.TestingPlatform
                     {
                         // todo - ICoverageProjectSettingsManager.GetSettingsAsync parameter 
                         // to change to what it actually needs
-                        coverageProject = new CoverageProject(appOptionsProvider, null, null, null, coverageProjectSettingsManager, false)
+                        coverageProject = new CoverageProject(appOptionsProvider, null, coverageProjectSettingsManager, null)
                         {
                             Id = projectGuid,
                             ProjectFile = unconfiguredProject.FullPath

--- a/SharedProject/Core/OpenCover/OpenCoverExeArgumentsProvider.cs
+++ b/SharedProject/Core/OpenCover/OpenCoverExeArgumentsProvider.cs
@@ -25,13 +25,13 @@ namespace FineCodeCoverage.Engine.OpenCover
         private enum Delimiter { Semicolon, Space}
         private void AddFilter(ICoverageProject project, List<string> opencoverSettings)
         {
-            var includedModules = project.IncludedReferencedProjects.ToList();
+            var includedModules = project.IncludedReferencedProjects.Select(rp => rp.AssemblyName).ToList();
             if (project.Settings.IncludeTestAssembly)
             {
                 includedModules.Add(project.ProjectName);
             }
             var includeFilters = GetExcludesOrIncludes(project.Settings.Include, includedModules, true);
-            var excludeFilters = GetExcludesOrIncludes(project.Settings.Exclude, project.ExcludedReferencedProjects,false);
+            var excludeFilters = GetExcludesOrIncludes(project.Settings.Exclude, project.ExcludedReferencedProjects.Select(rp => rp.AssemblyName), false);
             AddIncludeAllIfExcludingWithoutIncludes();
             var filters = includeFilters.Concat(excludeFilters).ToList();
             SafeAddToSettingsDelimitedIfAny(opencoverSettings, "filter", filters, Delimiter.Space);

--- a/SharedProject/Impl/TestContainerDiscovery/TestOperation.cs
+++ b/SharedProject/Impl/TestContainerDiscovery/TestOperation.cs
@@ -34,7 +34,7 @@ namespace FineCodeCoverage.Impl
             List<ICoverageProject> coverageProjects = new List<ICoverageProject>();
             foreach (var container in testContainers)
             {
-                var project = await coverageProjectFactory.CreateAsync();
+                var project = coverageProjectFactory.Create();
                 coverageProjects.Add(project);
                 project.ProjectName = container.ProjectName;
                 project.TestDllFile = container.Source;

--- a/SharedProject/Output/Directory.Build.props
+++ b/SharedProject/Output/Directory.Build.props
@@ -1,6 +1,0 @@
-<Project>
-  <!-- See https://aka.ms/dotnet/msbuild/customize for more details on customizing your build -->
-  <PropertyGroup>
-
-  </PropertyGroup>
-</Project>

--- a/SharedProject/SharedProject.projitems
+++ b/SharedProject/SharedProject.projitems
@@ -79,18 +79,30 @@
     <Compile Include="$(MSBuildThisFileDirectory)Core\Model\CoverageProjectFileSynchronizationDetails.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Model\CoverageProjectSettingsManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Model\CoverageProjectSettingsProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Core\Model\ReferencedProjects\CPPReferencedProjectsHelper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Core\Model\ReferencedProjects\DotNetReferencedProjectsHelper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Core\Model\ReferencedProjects\ProjectFileReferencedProjectsHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Model\FCCSettingsFilesProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Cobertura\FileLineCoverage.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Model\ICoverageProject.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Model\ICoverageProjectFactory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Model\ICoverageProjectSettingsManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Model\ICoverageProjectSettingsProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Core\Model\ReferencedProjects\ICPPReferencedProjectsHelper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Core\Model\ReferencedProjects\IDotNetReferencedProjectsHelper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Core\Model\ReferencedProjects\IExcludableReferencedProject.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Core\Model\ReferencedProjects\IProjectFileReferencedProjectsHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Model\IFCCSettingsFilesProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Cobertura\IFileLineCoverage.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Core\Model\ReferencedProjects\IReferencedProject.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Core\Model\ReferencedProjects\IReferencedProjectsHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Model\ISettingsMerger.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Core\Model\ReferencedProjects\IVsApiReferencedProjectsHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Model\IVsBuildFCCSettingsProvider.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Core\Model\ReferencedProject.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Core\Model\ReferencedProjects\ReferencedProject.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Core\Model\ReferencedProjects\ReferencedProjectsHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Model\SettingsMerger.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Core\Model\ReferencedProjects\VsApiReferencedProjectsHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Model\VsBuildFCCSettingsProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\MsTestPlatform\CodeCoverage\ITemplatedRunSettingsService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\MsTestPlatform\CodeCoverage\MsTemplateReplacementException.cs" />
@@ -443,10 +455,10 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)Editor\.editorconfig" />
-    <None Include="$(MSBuildThisFileDirectory)Output\Directory.Build.props" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="$(MSBuildThisFileDirectory)Core\Cobertura\Report\" />
+    <Folder Include="$(MSBuildThisFileDirectory)Core\Model\ReferencedProjects\" />
     <Folder Include="$(MSBuildThisFileDirectory)Editor\DynamicCoverage\NewCode\" />
     <Folder Include="$(MSBuildThisFileDirectory)Editor\DynamicCoverage\Dirty\" />
     <Folder Include="$(MSBuildThisFileDirectory)Editor\DynamicCoverage\Coverage\" />


### PR DESCRIPTION
…duce a dll.

Note that still have to include dll.  Improved referenced projects, VcProject and removed Msbuild locator.  ms regex now escapes dots.